### PR TITLE
Default for addHelp parameter is incorrect

### DIFF
--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -53,7 +53,7 @@ var Namespace = require('./namespace');
 var ArgumentParser = module.exports = function ArgumentParser(options) {
   options = options || {};
   options.prefixChars = (options.prefixChars || '-');
-  options.addHelp = (options.addHelp || false);
+  options.addHelp = (typeof options.addHelp === 'undefined' || !!options.addHelp);
   options.parents = (options.parents || []);
 
   options.argumentDefault = options.argumentDefault || null;


### PR DESCRIPTION
The default to the `addHelp` parameter for `ArgumentParser` is false, but is documented as true; the default in Python argparse is also True.

Test case in node:

```
#!/usr/bin/env node

var argparse = require("argparse");

(new argparse.ArgumentParser()).printHelp();

// usage: defaultHelp.js
//
```

Test case in Python:

```
#!/usr/bin/env python

import argparse

argparse.ArgumentParser().print_help()

# usage: default_help.py [-h]
#
# optional arguments:
#   -h, --help  show this help message and exit
#
```

The commit in this pull request will cause `addHelp` to default to true IFF its type is `unknown`; otherwise, it will use its value as a boolean.
