### PR TITLE
Support -- to denote positional arguments

### DIFF
--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -312,9 +312,10 @@ ArgumentParser.prototype._parseKnownArgs = function (argStrings, namespace) {
   argStrings.forEach(function (argString, argStringIndex) {
     if (argString === '--'){
       argStringPatternParts.push('-');
-      argString.forEach(function(forString) {
+      while (argStringIndex < argStrings.length) {
         argStringPatternParts.push('A');
-      });
+        argStringIndex++;
+      }
     }
     // otherwise, add the arg to the arg strings
     // and note the index if it was an option

--- a/test/base.js
+++ b/test/base.js
@@ -55,6 +55,13 @@ describe('ArgumentParser', function () {
         /too few arguments/
       );
     });
+
+    it("should support positional args", function() {
+      parser.addArgument([ 'bar' ], { nargs: '+' });
+      args = parser.parseArgs([ '-f', 'foo', '--', '-f', 'bar' ]);
+      assert.equal(args.foo, 'foo');
+      assert.equal(args.bar.length, 2);
+    });
   });
 });
 


### PR DESCRIPTION
The python version of the library support passing -- as the end of the options and the beginning of the arguments. It looks like there was code that tried to do this, but I added a quick test and fixed it up.
