### PR TITLE
Fix parser #setDefaults and add tests

### DIFF
--- a/lib/action_container.js
+++ b/lib/action_container.js
@@ -128,7 +128,7 @@ ActionContainer.prototype.setDefaults = function (options) {
   // if these defaults match any existing arguments, replace the previous
   // default on the object with the new one
   this._actions.forEach(function (action) {
-    if (options.indexOf(action.dest) >= 0) {
+    if (action.dest in options) {
       action.defaultValue = options[action.dest];
     }
   });

--- a/test/base.js
+++ b/test/base.js
@@ -62,6 +62,12 @@ describe('ArgumentParser', function () {
       assert.equal(args.foo, 'foo');
       assert.equal(args.bar.length, 2);
     });
+
+    it("should support #setDefaults", function() {
+      parser.setDefaults({bar: 1});
+      args = parser.parseArgs([]);
+      assert.equal(args.bar, 1);
+    });
   });
 });
 

--- a/test/sub_commands.js
+++ b/test/sub_commands.js
@@ -11,6 +11,8 @@ describe('ArgumentParser', function () {
   describe('sub-commands', function () {
     var parser;
     var args;
+    var c1;
+    var c2;
 
     beforeEach(function() {
       parser = new ArgumentParser({debug: true});
@@ -18,10 +20,10 @@ describe('ArgumentParser', function () {
         title:'subcommands',
         dest:"subcommand_name"
       });
-      var c1 = subparsers.addParser('c1', {aliases:['co']});
+      c1 = subparsers.addParser('c1', {aliases:['co']});
       c1.addArgument([ '-f', '--foo' ], {});
       c1.addArgument([ '-b', '--bar' ], {});
-      var c2 = subparsers.addParser('c2', {});
+      c2 = subparsers.addParser('c2', {});
       c2.addArgument([ '--baz' ], {});
     });
 
@@ -62,6 +64,17 @@ describe('ArgumentParser', function () {
         function () {parser.parseArgs([]); },
         /too few arguments/
       );
+    });
+
+    it("should support #setDefaults", function() {
+      c1.setDefaults({spam: 1});
+      c2.setDefaults({eggs: 2});
+      args = parser.parseArgs(['c1']);
+      assert.equal(args.spam, 1);
+      assert.strictEqual(args.eggs, undefined);
+      args = parser.parseArgs(['c2']);
+      assert.equal(args.eggs, 2);
+      assert.strictEqual(args.spam, undefined);
     });
   });
 });


### PR DESCRIPTION
ActionContainer#setDefaults takes an object as its argument, but was treating
it as an array.
