### PR TITLE
Correction to inferring action.dest from option strings

### DIFF
--- a/examples/short_dest.js
+++ b/examples/short_dest.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+'use strict';
+
+var ArgumentParser = require('../lib/argparse').ArgumentParser;
+var parser = new ArgumentParser({
+  version: '0.0.1',
+  addHelp: true,
+  description: 'Argparse examples: inferring the option dest'
+});
+parser.addArgument(['-f', '--foo']); // from longoption
+parser.addArgument(['-g']);  // from short option
+parser.addArgument(['-x'],{dest:'xxx'}); // from dest keyword
+parser.addArgument(['--foo-bar']); // '-' to '_'
+
+parser.printHelp();
+console.log('-----------');
+
+var args;
+args = parser.parseArgs(['-f', '1']);
+console.dir(args);
+args = parser.parseArgs(['-g','2']);
+console.dir(args);
+args = parser.parseArgs(['-f',1,'-g',2,'-x',3,'--foo-bar','FOO BAR']);
+console.dir(args);
+// expect: { foo: 1, g: 2, xxx: 3, foo_bar: 'FOO BAR' }
+

--- a/lib/action_container.js
+++ b/lib/action_container.js
@@ -362,8 +362,9 @@ ActionContainer.prototype._getOptional = function (args, options) {
   delete options.dest;
   
   if (!dest) {
-    var optionStringDest = !!optionStringsLong ? optionStringsLong[0] :optionStrings[0];
-
+    // var optionStringDest = !!optionStringsLong ? optionStringsLong[0] :optionStrings[0];
+    // optionStringsLong is a (possibly empty) list
+    var optionStringDest = optionStringsLong.length ? optionStringsLong[0] :optionStrings[0];
     dest = _.str.strip(optionStringDest, this.prefixChars);
 
     if (dest.length === 0) {


### PR DESCRIPTION
In the absence of a long option string it failed to infer the dest from the short one.
examples/short_dest demonstrates this inferrence
