### PR TITLE
correct handling of default with * nargs

### DIFF
--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -835,7 +835,7 @@ ArgumentParser.prototype._getValues = function (action, argStrings) {
   // args, use the default if it is anything other than None
   } else if (argStrings.length === 0 &&
         action.nargs === $$.ZERO_OR_MORE &&
-        action.isOptional()) {
+        !action.isOptional()) {
 
     value = (action.defaultValue || argStrings);
     this._checkValue(action, value);

--- a/test/base.js
+++ b/test/base.js
@@ -108,6 +108,13 @@ describe('ArgumentParser', function () {
 
       assert.equal(args.bar, -1);
     });
+    
+    it("should accept defaultValue for nargs:'*'", function () {
+      parser.addArgument(['bar'], { nargs: '*', defaultValue: 42});
+      args = parser.parseArgs([]);
+      assert.equal(args.bar, 42);
+    });
+    
   });
 });
 


### PR DESCRIPTION
This corrects the handling of defaultValue when nargs:'*'
Test added to base.js
