### PR TITLE
minor correction to _registryGet()

### DIFF
--- a/lib/action_container.js
+++ b/lib/action_container.js
@@ -104,7 +104,7 @@ ActionContainer.prototype.register = function (registryName, value, object) {
 };
 
 ActionContainer.prototype._registryGet = function (registryName, value, defaultValue) {
-  defaultValue = defaultValue || null;
+  //defaultValue = defaultValue || null; // not 'defaultValue=None', not needed
   return this._registries[registryName][value] || defaultValue;
 };
 


### PR DESCRIPTION
Minor correction to _registryGet() function.  Python uses a default=None argument.
DefaultValue = defaultValue || null;  is not the same (for example if defaultValue=0)
However this function is always called with a value like action or action.type 
So  it is simplest to just omit the test.
This variable name is unrelated to the other uses of 'defaultValue'.
