### PR TITLE
correction to issue #31

### DIFF
--- a/lib/action/append/constant.js
+++ b/lib/action/append/constant.js
@@ -24,6 +24,9 @@ var Action = require('../../action');
 var ActionAppendConstant = module.exports = function ActionAppendConstant(options) {
   options = options || {};
   options.nargs = 0;
+  if (options.constant === undefined) {
+    throw new Error('constant option is required for appendAction');
+  }
   Action.call(this, options);
 };
 util.inherits(ActionAppendConstant, Action);

--- a/lib/action/store/constant.js
+++ b/lib/action/store/constant.js
@@ -22,6 +22,9 @@ var Action = require('../../action');
 var ActionStoreConstant = module.exports = function ActionStoreConstant(options) {
   options = options || {};
   options.nargs = 0;
+  if (options.constant === undefined) {
+    throw new Error('constant option is required for storeAction');
+  }
   Action.call(this, options);
 };
 util.inherits(ActionStoreConstant, Action);

--- a/test/constant.js
+++ b/test/constant.js
@@ -1,0 +1,54 @@
+/*global describe, it, beforeEach*/
+
+'use strict';
+
+var assert = require('assert');
+
+var ArgumentParser = require('../lib/argparse').ArgumentParser;
+
+describe('ArgumentParser', function () {
+  describe('constant actions', function () {
+    var parser;
+    var args;
+
+    beforeEach(function () {
+      parser = new ArgumentParser({debug: true});
+    });
+
+    it("storeConst should store constant as given", function () {
+      parser.addArgument(['-a'], {action: 'storeConst', dest:   'answer',
+            help:   'store constant', constant: 42});
+      args = parser.parseArgs('-a'.split(' '));
+      assert.equal(args.answer, '42');
+    });
+
+    it("storeConst should give error if constant not given (or misspelled)", function () {
+      assert.throws(
+        function () {
+            parser.addArgument(['-a'], {action: 'storeConst', dest:   'answer',
+                help:   'store constant', const: 42});
+          },
+        /constant option is required for storeAction/
+        );
+    });
+    
+    it("appendConst should append constant as given", function () {
+      parser.addArgument([ '--str' ], {action: 'appendConst', dest:   'types',
+        help:   'append constant "str" to types', constant: 'str'});
+      parser.addArgument([ '--int' ], {action: 'appendConst', dest:   'types',
+        help:   'append constant "int" to types', constant: 'int'});
+      args = parser.parseArgs('--str --int'.split(' '));
+      assert.deepEqual(args.types, [ 'str', 'int' ]);
+    });
+    
+    it("appendConst should give error if constant not given (or misspelled)", function () {
+      assert.throws(
+        function () {
+            parser.addArgument(['-a'], {action: 'appendConst', dest:   'answer',
+                help:   'store constant', const: 42});
+          },
+        /constant option is required for appendAction/
+      );
+    });
+  });
+});


### PR DESCRIPTION
`appendConst` and `storeConst` now give error if `constant` is not defined.  See test/constants.js
