### PR TITLE
This argparse failed the test_argparse.py TestOptionLike class

### DIFF
--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -607,7 +607,7 @@ ArgumentParser.prototype._parseKnownArgs = function (argStrings, namespace) {
 ArgumentParser.prototype._matchArgument = function (action, regexpArgStrings) {
 
   // match the pattern for this action to the arg strings
-  var regexpNargs = new RegExp(this._getNargsPattern(action));
+  var regexpNargs = new RegExp('^' + this._getNargsPattern(action));
   var matches = regexpArgStrings.match(regexpNargs);
   var message;
 
@@ -656,7 +656,7 @@ ArgumentParser.prototype._matchArgumentsPartial = function (actions, regexpArgSt
       pattern += self._getNargsPattern(actionSlice[j]);
     }
 
-    pattern = new RegExp(pattern);
+    pattern = new RegExp('^' + pattern);
     matches = regexpArgStrings.match(pattern);
 
     if (matches && matches.length > 0) {

--- a/test/testoptionlike.js
+++ b/test/testoptionlike.js
@@ -1,0 +1,49 @@
+/*global describe, it*/
+
+'use strict';
+
+var assert = require('assert');
+
+var ArgumentParser = require('../lib/argparse').ArgumentParser;
+describe('ArgumentParser', function () {
+  describe('....', function () {
+    var parser;
+    var args;
+
+    it("TestOptionLike", function () {
+      // Tests options that may or may not be arguments
+      parser = new ArgumentParser({debug: true});
+      parser.addArgument(['-x'], {type: 'float'});
+      parser.addArgument(['-3'], {type: 'float', dest: 'y'});
+      parser.addArgument(['z'], {nargs: '*'});
+      
+      args = parser.parseArgs([]);
+      assert.deepEqual(args, {x: null, y: null, z: []});
+      args = parser.parseArgs('-x 2.5 a'.split(' '));
+      assert.deepEqual(args, {x: 2.5, y: null, z: ['a']});
+      args = parser.parseArgs('-3 1 a'.split(' '));
+      assert.deepEqual(args, {x: null, y: 1.0, z: ['a']});
+      
+      assert.throws(function () {
+        parser.parseArgs('-x -2.5'.split(' '));
+      },
+      /expected one argument/i
+      );
+      assert.throws(function () {
+        parser.parseArgs('-x -2.5 a'.split(' '));
+      },
+      /expected one argument/i
+      );
+      // problem with missing '^' in pattern match
+      assert.throws(function () {
+        parser.parseArgs('-3 -1 a'.split(' '));
+      },
+      /expected one argument/i
+      );
+    });
+  });
+});
+
+/*
+
+*/


### PR DESCRIPTION
I have translated many of the test classes in test_argparse.py to mocha, and encountered errors in about 17 of these classes.   The tests all specify ArgumentParser(), addArgument(), and parseArgs() without defining special functions.

This is the first of 6 changes need to make js argparse pass the Python tests.

Args like '-x -2.5 a' are supposed to fail.
The problem is that Python match() starts the match at the start of a string.
Javascript match can match anywhere in the string.
Correction in argument_parser.js, matchArguments() and matchArgumentsPartial()
is to add '^' to the pattern.

TestOptionLike.js tests the change in matchArguments().  I don't know of a test
for the matchArgumentsPartial() change.
