### PR TITLE
Use of _.indexOf to search a Namespace is wrong

### DIFF
--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -258,7 +258,7 @@ ArgumentParser.prototype.parseKnownArgs = function (args, namespace) {
 
   self._actions.forEach(function (action) {
     if (action.dest !== $$.SUPPRESS) {
-      if (_.indexOf(namespace, action.dest) === -1) {
+      if (!_.has(namespace, action.dest)) {
         if (action.defaultValue !== $$.SUPPRESS) {
           var defaultValue = action.defaultValue;
           if (_.isString(action.defaultValue)) {
@@ -280,7 +280,7 @@ ArgumentParser.prototype.parseKnownArgs = function (args, namespace) {
     
     namespace = res[0];
     args = res[1];
-    if (_.indexOf(Namespace, $$._UNRECOGNIZED_ARGS_ATTR)  !== -1) {
+    if (_.has(namespace, $$._UNRECOGNIZED_ARGS_ATTR)) {
       args = _.union(args, namespace[$$._UNRECOGNIZED_ARGS_ATTR]);
       delete namespace[$$._UNRECOGNIZED_ARGS_ATTR];
     }

--- a/test/appendConstDefault.js
+++ b/test/appendConstDefault.js
@@ -1,0 +1,32 @@
+/*global describe, it*/
+
+'use strict';
+
+var assert = require('assert');
+
+var ArgumentParser = require('../lib/argparse').ArgumentParser;
+describe('ArgumentParser', function () {
+  describe('....', function () {
+    var parser;
+    var args;
+
+    it("TestOptionalsActionAppendConstWithDefault", function () {
+      // Tests the append_const action for an Optional
+      parser = new ArgumentParser({debug: true});
+      parser.addArgument(['-b'], {action: 'appendConst', constant: 'Exception', defaultValue: ['X']});
+      parser.addArgument(['-c'], {action: 'append', dest: 'b'});
+      
+      args = parser.parseArgs([]);
+      assert.deepEqual(args, {b: ['X']});
+      args = parser.parseArgs('-b'.split(' '));
+      assert.deepEqual(args, {b: ['X', 'Exception']});
+      args = parser.parseArgs('-b -cx -b -cyz'.split(' '));
+      assert.deepEqual(args, {b: ['X', 'Exception', 'x', 'Exception', 'yz']});
+      // problem is b not getting 'X' default
+    });
+  });
+});
+
+/*
+
+*/


### PR DESCRIPTION
ArgumentParser.parseKnownArgs() twice uses _indexOf(namespace, ...) to check the namespace object has a value.  It should use _.has() instead (or a corrected Namespace.isset()).

This argparse fails test_argparse.py TestOptionalsActionAppendConstWithDefault class.

This test has two actions with the same 'dest'.  The Python test expects
the defaultValue of the 1st action to apply, but the JS code uses the 2nd's
defaultValue (or lack there of).

The correction is to change how ArgumentParser.parseKnownArgs() checks the
namespace for a value.  A namespace is object-like, so indexOf is wrong.
Change this to _.has().  The indexOf version, besides applying to the wrong
kind of object, always returns true (the key is never found).

Namespace handling could be cleaned up.  Sometimes it is accessed with
object methods, sometimes with its own set and isset.  Also its handling
of null differs from the Python (more on this in another pull).
