### PR TITLE
Optionals with '*' should accept a defaultValue

### DIFF
--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -874,7 +874,8 @@ ArgumentParser.prototype._getValues = function (action, argStrings) {
 
   // when nargs='*' on a positional, if there were no command-line
   // args, use the default if it is anything other than None
-  } else if (argStrings.length === 0 && action.nargs === $$.ZERO_OR_MORE) {
+  } else if (argStrings.length === 0 && action.nargs === $$.ZERO_OR_MORE &&
+    action.optionStrings.length === 0) {
 
     value = (action.defaultValue || argStrings);
     this._checkValue(action, value);

--- a/test/optionalstar.js
+++ b/test/optionalstar.js
@@ -1,0 +1,32 @@
+/*global describe, it*/
+
+'use strict';
+
+var assert = require('assert');
+
+var ArgumentParser = require('../lib/argparse').ArgumentParser;
+describe('ArgumentParser', function () {
+  describe('....', function () {
+    var parser;
+    var args;
+
+    it("TestOptionalsNargsZeroOrMore(ParserTestCase", function () {
+      // Tests specifying an args for an Optional that accepts zero or more
+      parser = new ArgumentParser({debug: true});
+      parser.addArgument(['-x'], {nargs: '*'});
+      parser.addArgument(['-y'], {nargs: '*', defaultValue: 'spam'});
+      
+      args = parser.parseArgs([]);
+      assert.deepEqual(args, {x: null, y: 'spam'});
+      args = parser.parseArgs('-x a b'.split(' '));
+      assert.deepEqual(args, {x: ['a', 'b'], y: 'spam'});
+      args = parser.parseArgs('-y'.split(' '));
+      assert.deepEqual(args, {x: null, y: []});
+      // problem is y not getting its default
+    });
+  });
+});
+
+/*
+
+*/


### PR DESCRIPTION
JS argparse fails the test_argparse.py test for TestOptionalsNargsZeroOrMore(ParserTestCase
Tests specifying an args for an Optional that accepts zero or more

In this case ['-y'] with nargs='_' and defaultValue= 'spam', should be
using that default.  (Positionals with '_' on the other hand don't)

Correction: test for optionStrings.length in ArgumentParser._getValues()
Action.isPositional() does the same thing.
