### PR TITLE
Correct 'help' when argumentDefault and prefixChars options are used

### DIFF
--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -100,21 +100,24 @@ var ArgumentParser = module.exports = function ArgumentParser(options) {
   });
 
   // add help and version arguments if necessary
+  var defaultPrefix = (this.prefixChars.indexOf('-') > -1) ? '-' : this.prefixChars[0];
   if (options.addHelp) {
     this.addArgument(
-      ['-h', '--help'],
+      [defaultPrefix + 'h', defaultPrefix + defaultPrefix + 'help'],
       {
         action: 'help',
+        defaultValue: $$.SUPPRESS,
         help: 'Show this help message and exit.'
       }
     );
   }
   if (this.version !== undefined) {
     this.addArgument(
-      ['-v', '--version'],
+      [defaultPrefix + 'v', defaultPrefix + defaultPrefix + 'version'],
       {
         action: 'version',
         version: this.version,
+        defaultValue: $$.SUPPRESS,
         help: "Show program's version number and exit."
       }
     );

--- a/test/helpargs.js
+++ b/test/helpargs.js
@@ -1,0 +1,44 @@
+/*global describe, it*/
+
+'use strict';
+
+var assert = require('assert');
+
+var ArgumentParser = require('../lib/argparse').ArgumentParser;
+describe('ArgumentParser', function () {
+  describe('....', function () {
+    var parser;
+    var args;
+    
+    it("TestParserDefault42", function () {
+      // Test actions with a parser-level default of 42
+      parser = new ArgumentParser({debug: true, argumentDefault: 42, version: '1.0'});
+      parser.addArgument(['foo'], {nargs: '?'});
+      parser.addArgument(['bar'], {nargs: '*'});
+      parser.addArgument(['--baz'], {action: 'storeTrue'});
+
+      args = parser.parseArgs([]);
+      assert.deepEqual(args, {bar: 42, foo: 42, baz: 42 });
+      // problem is with 42 being assigned as default to help
+    });
+    
+    it("TestOptionalsAlternatePrefixCharsAddedHelp", function () {
+      /* When ``-`` not in prefix_chars, default operators created for help
+      *  should use the prefix_chars in use rather than - or --
+      *  http://bugs.python.org/issue9444
+      */
+      parser = new ArgumentParser({debug: true, prefixChars: '+:/', addHelp: true});
+      parser.addArgument(['+f'], {action: 'storeTrue'});
+      parser.addArgument(['::bar']);
+      parser.addArgument(['/baz'], {action: 'storeConst', constant: 42});
+      // parser.printHelp()
+      args = parser.parseArgs([]);
+      assert.deepEqual(args, {f: false, bar: null, baz: null});
+      //
+    });
+  });
+});
+
+/*
+
+*/


### PR DESCRIPTION
argparse.js fails 2 help related tests in `test_argparse.py`

`TestParserDefault42` sets a parser `argumentDefault`
The error is that the namespace includes `{help: 42, version: 42}`
Correction: add `defaultValue: $$.SUPPRESS` when defining --help and --version
in ArgumentParser().

`TestOptionalsAlternatePrefixCharsAddedHelp` sets `prefixChars`.
If `prefixChars` does not include '-', setting `['-h','--help']` gives an error.
Correction: set a `defaultPrefix` that is either '-' or the first `prefixChar`,
and use this instead of '-h'
