### PR TITLE
action/append should `push` new values, not `concat`

### DIFF
--- a/lib/action/append.js
+++ b/lib/action/append.js
@@ -47,7 +47,8 @@ util.inherits(ActionAppend, Action);
  * Call the action. Save result in namespace object
  **/
 ActionAppend.prototype.call = function (parser, namespace, values) {
-  var items = [].concat(namespace[this.dest] || [], values);
+  var items = [].concat(namespace[this.dest] || []); // or _.clone
+  items.push(values);
   namespace.set(this.dest, items);
 };
 

--- a/test/positionalappend.js
+++ b/test/positionalappend.js
@@ -1,0 +1,28 @@
+/*global describe, it*/
+
+'use strict';
+
+var assert = require('assert');
+
+var ArgumentParser = require('../lib/argparse').ArgumentParser;
+describe('ArgumentParser', function () {
+  describe('....', function () {
+    var parser;
+    var args;
+    
+    it("TestPositionalsActionAppend", function () {
+      // Test the 'append' action
+      parser = new ArgumentParser({debug: true});
+      parser.addArgument(['spam'], {action: 'append'});
+      parser.addArgument(['spam'], {action: 'append', nargs: 2});
+
+      args = parser.parseArgs('a b c'.split(' '));
+      assert.deepEqual(args, {spam: [ 'a', [ 'b', 'c' ] ]});
+      //
+    });
+  });
+});
+
+/*
+
+*/


### PR DESCRIPTION
In `test_argparse.py` `TestPositionalsActionAppend` has 2 positional args, one that takes 1 argument, the other 2.
`parseArgs` with `'a b c'` produces `spam: ['a','b','c']`, but python expects `spam: ['a', ['b','c']]`.
This is because append.js uses `concat`, while python uses `append`.

Correction: change `action/append.js set()` to use `push()`
