### PR TITLE
Change Namespace to handle null values as Python does for None

### DIFF
--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -28,7 +28,7 @@ var Namespace = module.exports = function Namespace(options) {
  * Tells whenever `namespace` contains given `key` or not.
  **/
 Namespace.prototype.isset = function (key) {
-  return !!this[key];
+  return _.has(this, key);
 };
 
 /**
@@ -43,11 +43,7 @@ Namespace.prototype.set = function (key, value) {
   if (typeof (key) === 'object') {
     _.extend(this, key);
   } else {
-    if (value !== null) {
-      this[key] = value;
-    } else {
-      delete this[key];
-    }
+    this[key] = value;
   }
   return this;
 };

--- a/test/namespace.js
+++ b/test/namespace.js
@@ -1,0 +1,23 @@
+/*global describe, it*/
+
+'use strict';
+
+var assert = require('assert');
+
+var ArgumentParser = require('../lib/argparse').ArgumentParser;
+describe('ArgumentParser', function () {
+  describe('....', function () {
+    var parser;
+    var args;
+        
+    it("TestPositionalsNargsOptional", function () {
+      // Tests an Optional Positional
+      parser = new ArgumentParser({debug: true});
+      parser.addArgument(['foo'], {nargs: '?'});
+
+      args = parser.parseArgs([]);
+      assert.deepEqual(args, {foo: null});
+      // sample case where null value is not in the namespace
+    });
+  });
+});


### PR DESCRIPTION
`TestPositionalsNargsOptional` adapted from `test_argparse.py` gives an error
`'AssertionError: {} deepEqual {"foo":null}'`

A dozen other classes in the py test file give similar errors.
The problem is that the JS `Namespace` class treats `null` differently than the python `None`.

Python gives every `dest` at least a `None` value.
The JS `Namespace` tries to treat a `null` value as the same as `undefined`.
However, because sometimes values are set with `Namespace.set()`, and other
times with ordinary object assignment, sometimes a null value appears in
a namespace.

These tests do pass if a modified deepEqual is used, one that ignores
differences between `{bar: null}` and `{}`

Python has a special `Namespace` class because its base `Object` class does
not directly accept attributes.  It also defines a nice display method.
The resulting class is essentially the same as the Javascript `object`.

To better match the Python:
- change `namespace.isset()` to use `_.has()` instead of `!!` (`!!null` is `false`)
- remove the null test in `namespace.set()`
- the `_.extend()` alternative is not used.
- `namespace.get()` is not used
