### PR TITLE
#1 Add additional help formatters

### DIFF
--- a/examples/testformatters.js
+++ b/examples/testformatters.js
@@ -1,0 +1,270 @@
+'use strict';
+
+var a, group, parser, helptext;
+
+var assert = require('assert');
+var _ = require('underscore');
+_.str = require('underscore.string');
+var print = function () {
+    return console.log.apply(console, arguments);
+  };
+// print = function () {};
+
+var argparse = require('argparse');
+
+print("TEST argparse.ArgumentDefaultsHelpFormatter");
+
+parser = new argparse.ArgumentParser({
+  debug: true,
+  formatterClass: argparse.ArgumentDefaultsHelpFormatter,
+  description: 'description'
+});
+
+parser.addArgument(['--foo'], {
+  help: 'foo help - oh and by the way, %(defaultValue)s'
+});
+
+parser.addArgument(['--bar'], {
+  action: 'storeTrue',
+  help: 'bar help'
+});
+
+parser.addArgument(['spam'], {
+  help: 'spam help'
+});
+
+parser.addArgument(['badger'], {
+  nargs: '?',
+  defaultValue: 'wooden',
+  help: 'badger help'
+});
+
+group = parser.addArgumentGroup({
+  title: 'title',
+  description: 'group description'
+});
+
+group.addArgument(['--baz'], {
+  type: 'int',
+  defaultValue: 42,
+  help: 'baz help'
+});
+
+helptext = parser.formatHelp();
+print(helptext);
+// test selected clips
+assert(helptext.match(/badger help \(default: wooden\)/));
+assert(helptext.match(/foo help - oh and by the way, null/));
+assert(helptext.match(/bar help \(default: false\)/));
+assert(helptext.match(/title:\n {2}group description/)); // test indent
+assert(helptext.match(/baz help \(default: 42\)/im));
+
+/*
+usage: PROG [-h] [--foo FOO] [--bar] [--baz BAZ] spam [badger]
+
+description
+
+positional arguments:
+  spam        spam help
+  badger      badger help (default: wooden)
+
+optional arguments:
+  -h, --help  show this help message and exit
+  --foo FOO   foo help - oh and by the way, null
+  --bar       bar help (default: false)
+
+title:
+  group description
+
+  --baz BAZ   baz help (default: 42)
+*/
+
+print("TEST argparse.RawDescriptionHelpFormatter");
+
+parser = new argparse.ArgumentParser({
+  debug: true,
+  prog: 'PROG',
+  formatterClass: argparse.RawDescriptionHelpFormatter,
+  description: 'Keep the formatting\n' +
+               '    exactly as it is written\n' +
+               '\n' +
+               'here\n'
+});
+
+a = parser.addArgument(['--foo'], {
+  help: '  foo help should not\n' +
+        '    retain this odd formatting'
+});
+
+parser.addArgument(['spam'], {
+  'help': 'spam help'
+});
+
+group = parser.addArgumentGroup({
+  title: 'title',
+  description: '    This text\n' +
+               '  should be indented\n' +
+               '    exactly like it is here\n'
+});
+
+group.addArgument(['--bar'], {
+  help: 'bar help'
+});
+
+helptext = parser.formatHelp();
+print(helptext);
+// test selected clips
+assert(helptext.match(parser.description));
+assert.equal(helptext.match(a.help), null);
+assert(helptext.match(/foo help should not retain this odd formatting/));
+
+/*
+class TestHelpRawDescription(HelpTestCase):
+    """Test the RawTextHelpFormatter"""
+....
+
+usage: PROG [-h] [--foo FOO] [--bar BAR] spam
+
+Keep the formatting
+    exactly as it is written
+
+here
+
+positional arguments:
+  spam        spam help
+
+optional arguments:
+  -h, --help  show this help message and exit
+  --foo FOO   foo help should not retain this odd formatting
+
+title:
+      This text
+    should be indented
+      exactly like it is here
+
+  --bar BAR   bar help
+*/
+
+
+print("TEST argparse.RawTextHelpFormatter");
+
+parser = new argparse.ArgumentParser({
+  debug: true,
+  prog: 'PROG',
+  formatterClass: argparse.RawTextHelpFormatter,
+  description: 'Keep the formatting\n' +
+               '    exactly as it is written\n' +
+               '\n' +
+               'here\n'
+});
+
+parser.addArgument(['--baz'], {
+  help: '    baz help should also\n' +
+        'appear as given here'
+});
+
+a = parser.addArgument(['--foo'], {
+  help: '  foo help should also\n' +
+        'appear as given here'
+});
+
+parser.addArgument(['spam'], {
+  'help': 'spam help'
+});
+
+group = parser.addArgumentGroup({
+  title: 'title',
+  description: '    This text\n' +
+               '  should be indented\n' +
+               '    exactly like it is here\n'
+});
+
+group.addArgument(['--bar'], {
+  help: 'bar help'
+});
+
+helptext = parser.formatHelp();
+print(helptext);
+// test selected clips
+assert(helptext.match(parser.description));
+assert(helptext.match(/( {14})appear as given here/gm));
+
+/*
+class TestHelpRawText(HelpTestCase):
+    """Test the RawTextHelpFormatter"""
+
+usage: PROG [-h] [--foo FOO] [--bar BAR] spam
+
+Keep the formatting
+    exactly as it is written
+
+here
+
+positional arguments:
+  spam        spam help
+
+optional arguments:
+  -h, --help  show this help message and exit
+  --foo FOO       foo help should also
+              appear as given here
+
+title:
+      This text
+    should be indented
+      exactly like it is here
+
+  --bar BAR   bar help
+*/
+
+
+print("TEST metavar as a tuple");
+
+parser = new argparse.ArgumentParser({
+  prog: 'PROG'
+});
+
+parser.addArgument(['-w'], {
+  help: 'w',
+  nargs: '+',
+  metavar: ['W1', 'W2']
+});
+
+parser.addArgument(['-x'], {
+  help: 'x',
+  nargs: '*',
+  metavar: ['X1', 'X2']
+});
+
+parser.addArgument(['-y'], {
+  help: 'y',
+  nargs: 3,
+  metavar: ['Y1', 'Y2', 'Y3']
+});
+
+parser.addArgument(['-z'], {
+  help: 'z',
+  nargs: '?',
+  metavar: ['Z1']
+});
+
+helptext = parser.formatHelp();
+print(helptext);
+var ustring = 'PROG [-h] [-w W1 [W2 ...]] [-x [X1 [X2 ...]]] [-y Y1 Y2 Y3] [-z [Z1]]';
+ustring = ustring.replace(/\[/g, '\\[').replace(/\]/g, '\\]');
+// print(ustring)
+assert(helptext.match(new RegExp(ustring)));
+
+/*
+class TestHelpTupleMetavar(HelpTestCase):
+    """Test specifying metavar as a tuple"""
+
+usage: PROG [-h] [-w W1 [W2 ...]] [-x [X1 [X2 ...]]] [-y Y1 Y2 Y3] [-z [Z1]]
+
+optional arguments:
+  -h, --help        show this help message and exit
+  -w W1 [W2 ...]    w
+  -x [X1 [X2 ...]]  x
+  -y Y1 Y2 Y3       y
+  -z [Z1]           z
+*/
+

--- a/lib/argparse.js
+++ b/lib/argparse.js
@@ -5,3 +5,10 @@ module.exports.Namespace = require('./namespace');
 module.exports.Action = require('./action');
 module.exports.HelpFormatter = require('./help/formatter.js');
 module.exports.Const = require('./const.js');
+
+module.exports.ArgumentDefaultsHelpFormatter =
+  require('./help/added_formatters.js').ArgumentDefaultsHelpFormatter;
+module.exports.RawDescriptionHelpFormatter =
+  require('./help/added_formatters.js').RawDescriptionHelpFormatter;
+module.exports.RawTextHelpFormatter =
+  require('./help/added_formatters.js').RawTextHelpFormatter;

--- a/lib/help/added_formatters.js
+++ b/lib/help/added_formatters.js
@@ -1,0 +1,88 @@
+'use strict';
+
+var util    = require('util');
+var _ = require('underscore');
+_.str = require('underscore.string');
+
+// Constants
+var $$ = require('../const');
+
+var HelpFormatter = require('./formatter.js');
+
+/**
+ * new RawDescriptionHelpFormatter(options)
+ * new ArgumentParser({formatterClass: argparse.RawDescriptionHelpFormatter, ...})
+ *
+ * Help message formatter which adds default values to argument help.
+ *
+ * Only the name of this class is considered a public API. All the methods
+ * provided by the class are considered an implementation detail.
+ **/
+
+var ArgumentDefaultsHelpFormatter = function ArgumentDefaultsHelpFormatter(options) {
+  HelpFormatter.call(this, options);
+};
+
+util.inherits(ArgumentDefaultsHelpFormatter, HelpFormatter);
+
+ArgumentDefaultsHelpFormatter.prototype._getHelpString = function (action) {
+  var help = action.help;
+  if (action.help.indexOf('%(defaultValue)s') === -1) {
+    if (action.defaultValue !== $$.SUPPRESS) {
+      var defaulting_nargs = [$$.OPTIONAL, $$.ZERO_OR_MORE];
+      if (action.isOptional() || (defaulting_nargs.indexOf(action.nargs) >= 0)) {
+        help += ' (default: %(defaultValue)s)';
+      }
+    }
+  }
+  return help;
+};
+
+module.exports.ArgumentDefaultsHelpFormatter = ArgumentDefaultsHelpFormatter;
+
+/**
+ * new RawDescriptionHelpFormatter(options)
+ * new ArgumentParser({formatterClass: argparse.RawDescriptionHelpFormatter, ...})
+ *
+ * Help message formatter which retains any formatting in descriptions.
+ *
+ * Only the name of this class is considered a public API. All the methods
+ * provided by the class are considered an implementation detail.
+ **/
+
+var RawDescriptionHelpFormatter = function RawDescriptionHelpFormatter(options) {
+  HelpFormatter.call(this, options);
+};
+
+util.inherits(RawDescriptionHelpFormatter, HelpFormatter);
+
+RawDescriptionHelpFormatter.prototype._fillText = function (text, width, indent) {
+  var lines = text.split('\n');
+  lines = lines.map(function (line) {
+      return _.str.rtrim(indent + line);
+    });
+  return lines.join('\n');
+};
+module.exports.RawDescriptionHelpFormatter = RawDescriptionHelpFormatter;
+
+/**
+ * new RawTextHelpFormatter(options)
+ * new ArgumentParser({formatterClass: argparse.RawTextHelpFormatter, ...})
+ *
+ * Help message formatter which retains formatting of all help text.
+ *
+ * Only the name of this class is considered a public API. All the methods
+ * provided by the class are considered an implementation detail.
+ **/
+
+var RawTextHelpFormatter = function RawTextHelpFormatter(options) {
+  RawDescriptionHelpFormatter.call(this, options);
+};
+
+util.inherits(RawTextHelpFormatter, RawDescriptionHelpFormatter);
+
+RawTextHelpFormatter.prototype._splitLines = function (text) {
+  return text.split('\n');
+};
+
+module.exports.RawTextHelpFormatter = RawTextHelpFormatter;

--- a/lib/help/formatter.js
+++ b/lib/help/formatter.js
@@ -477,7 +477,7 @@ HelpFormatter.prototype._formatActionsUsage = function (actions, groups) {
 
   // collect all actions format strings
   var parts = [];
-  
+
   actions.forEach(function (action, actionIndex) {
     var part;
     var optionString;
@@ -792,8 +792,8 @@ HelpFormatter.prototype._splitLines = function (text, width) {
 
 HelpFormatter.prototype._fillText = function (text, width, indent) {
   var lines = this._splitLines(text, width);
-  lines.forEach(function (line) {
-    line = indent + line;
+  lines = lines.map(function (line) {
+    return indent + line;
   });
   return lines.join($$.EOL);
 };

--- a/test/formatters.js
+++ b/test/formatters.js
@@ -1,0 +1,259 @@
+/*global describe, it*/
+'use strict';
+
+var assert = require('assert');
+var _ = require('underscore');
+_.str = require('underscore.string');
+
+var argparse = require('argparse');
+
+describe('formatterClass alternatives', function () {
+  var a, group, parser, helptext;
+
+  it('ArgumentDefaultsHelpFormatter', function () {
+
+    parser = new argparse.ArgumentParser({
+      debug: true,
+      formatterClass: argparse.ArgumentDefaultsHelpFormatter,
+      description: 'description'
+    });
+
+    parser.addArgument(['--foo'], {
+      help: 'foo help - oh and by the way, %(defaultValue)s'
+    });
+
+    parser.addArgument(['--bar'], {
+      action: 'storeTrue',
+      help: 'bar help'
+    });
+
+    parser.addArgument(['spam'], {
+      help: 'spam help'
+    });
+
+    parser.addArgument(['badger'], {
+      nargs: '?',
+      defaultValue: 'wooden',
+      help: 'badger help'
+    });
+
+    group = parser.addArgumentGroup({
+      title: 'title',
+      description: 'group description'
+    });
+
+    group.addArgument(['--baz'], {
+      type: 'int',
+      defaultValue: 42,
+      help: 'baz help'
+    });
+
+    helptext = parser.formatHelp();
+    // test selected clips
+    // test_argparse.py can match the whole help
+    assert(helptext.match(/badger help \(default: wooden\)/));
+    assert(helptext.match(/foo help - oh and by the way, null/));
+    assert(helptext.match(/bar help \(default: false\)/));
+    assert(helptext.match(/title:\n {2}group description/)); // test indent
+    assert(helptext.match(/baz help \(default: 42\)/im));
+
+/*
+usage: PROG [-h] [--foo FOO] [--bar] [--baz BAZ] spam [badger]
+
+description
+
+positional arguments:
+  spam        spam help
+  badger      badger help (default: wooden)
+
+optional arguments:
+  -h, --help  show this help message and exit
+  --foo FOO   foo help - oh and by the way, null
+  --bar       bar help (default: false)
+
+title:
+  group description
+
+  --baz BAZ   baz help (default: 42)
+*/
+  });
+
+  it('RawDescriptionHelpFormatter', function () {
+
+    parser = new argparse.ArgumentParser({
+      debug: true,
+      prog: 'PROG',
+      formatterClass: argparse.RawDescriptionHelpFormatter,
+      description: 'Keep the formatting\n' +
+                   '    exactly as it is written\n' +
+                   '\n' +
+                   'here\n'
+    });
+
+    a = parser.addArgument(['--foo'], {
+      help: '  foo help should not\n' +
+            '    retain this odd formatting'
+    });
+
+    parser.addArgument(['spam'], {
+      'help': 'spam help'
+    });
+
+    group = parser.addArgumentGroup({
+      title: 'title',
+      description: '    This text\n' +
+                   '  should be indented\n' +
+                   '    exactly like it is here\n'
+    });
+
+    group.addArgument(['--bar'], {
+      help: 'bar help'
+    });
+
+    helptext = parser.formatHelp();
+    // test selected clips
+    // the parser description is not changed
+    assert(helptext.match(parser.description));
+    // the argument help is changed
+    assert.equal(helptext.match(a.help), null);
+    // the trimmed argument help matches
+    assert(helptext.match(/foo help should not retain this odd formatting/));
+
+/*
+usage: PROG [-h] [--foo FOO] [--bar BAR] spam
+
+Keep the formatting
+    exactly as it is written
+
+here
+
+positional arguments:
+  spam        spam help
+
+optional arguments:
+  -h, --help  show this help message and exit
+  --foo FOO   foo help should not retain this odd formatting
+
+title:
+      This text
+    should be indented
+      exactly like it is here
+
+  --bar BAR   bar help
+*/
+  });
+
+  it('RawTextHelpFormatter', function () {
+    parser = new argparse.ArgumentParser({
+      debug: true,
+      prog: 'PROG',
+      formatterClass: argparse.RawTextHelpFormatter,
+      description: 'Keep the formatting\n' +
+                   '    exactly as it is written\n' +
+                   '\n' +
+                   'here\n'
+    });
+
+    parser.addArgument(['--baz'], {
+      help: '    baz help should also\n' +
+            'appear as given here'
+    });
+
+    a = parser.addArgument(['--foo'], {
+      help: '  foo help should also\n' +
+            'appear as given here'
+    });
+
+    parser.addArgument(['spam'], {
+      'help': 'spam help'
+    });
+
+    group = parser.addArgumentGroup({
+      title: 'title',
+      description: '    This text\n' +
+                   '  should be indented\n' +
+                   '    exactly like it is here\n'
+    });
+
+    group.addArgument(['--bar'], {
+      help: 'bar help'
+    });
+
+    helptext = parser.formatHelp();
+    // test selected clips
+    assert(helptext.match(parser.description));
+    // part of the unchanged argument help, with spaces
+    assert(helptext.match(/( {14})appear as given here/gm));
+
+/*
+usage: PROG [-h] [--foo FOO] [--bar BAR] spam
+
+Keep the formatting
+    exactly as it is written
+
+here
+
+positional arguments:
+  spam        spam help
+
+optional arguments:
+  -h, --help  show this help message and exit
+  --foo FOO       foo help should also
+              appear as given here
+
+title:
+      This text
+    should be indented
+      exactly like it is here
+
+  --bar BAR   bar help
+*/
+  });
+
+  it('should handle metavar as an array', function () {
+    parser = new argparse.ArgumentParser({
+      prog: 'PROG'
+    });
+
+    parser.addArgument(['-w'], {
+      help: 'w',
+      nargs: '+',
+      metavar: ['W1', 'W2']
+    });
+
+    parser.addArgument(['-x'], {
+      help: 'x',
+      nargs: '*',
+      metavar: ['X1', 'X2']
+    });
+
+    parser.addArgument(['-y'], {
+      help: 'y',
+      nargs: 3,
+      metavar: ['Y1', 'Y2', 'Y3']
+    });
+
+    parser.addArgument(['-z'], {
+      help: 'z',
+      nargs: '?',
+      metavar: ['Z1']
+    });
+
+    helptext = parser.formatHelp();
+    var ustring = 'PROG [-h] [-w W1 [W2 ...]] [-x [X1 [X2 ...]]] [-y Y1 Y2 Y3] [-z [Z1]]';
+    ustring = ustring.replace(/\[/g, '\\[').replace(/\]/g, '\\]');
+    // have to escape all of those brackets
+    assert(helptext.match(new RegExp(ustring)));
+
+/*
+usage: PROG [-h] [-w W1 [W2 ...]] [-x [X1 [X2 ...]]] [-y Y1 Y2 Y3] [-z [Z1]]
+
+optional arguments:
+  -h, --help        show this help message and exit
+  -w W1 [W2 ...]    w
+  -x [X1 [X2 ...]]  x
+  -y Y1 Y2 Y3       y
+  -z [Z1]           z
+*/
+  });
+});


### PR DESCRIPTION
lib/help/added_formatters.js - HelpFormatter subclasses to
- include defaults in the argument help lines
- display descriptions in raw form (without reformatting)
- display all text in raw form

The ArgumentDefaultsHelpFormatter is probably the most useful.

lib/argparse.js - exports these new classes.

test/formatter.js - mocha tests, taken from test_argparse.py
    tests clips from the parser.formatHelp() text.
    It includes a test for array metavars.

examples/testformatters.js - same examples, but displays the help text.

formatter.js - _fillText, change forEach to map to correctly indent.
    mainly affects group descriptions.
