### PR TITLE
Correct license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "contributors"    : ["Eugene Shkuropat", "Paul Jacobson"],
 
   "bugs"            : { "url": "https://github.com/nodeca/argparse/issues" },
-  "license"         : { "type": "MIT", "url": "https://github.com/nodeca/argparse/blob/master/LICENSE" },
+  "license"         : "MIT",
   "repository"      : { "type": "git", "url": "git://github.com/nodeca/argparse.git" },
 
   "main"            : "./index.js",


### PR DESCRIPTION
A tiny update to the license field!
See [spec](https://www.npmjs.org/doc/files/package.json.html#license), [validator](https://github.com/gorillamania/package.json-validator/blob/08c9223a4c402b732b172fbf7b6dd11ef80ea6e7/PJV.js#L27).
