### PR TITLE
underscore.string upgraded to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 
    "dependencies"   : {
                         "underscore"        : "~1.4.3",
-                        "underscore.string" : "~2.3.1"
+                        "underscore.string" : "~2.4.0"
                       },
   "devDependencies" : { "mocha": "*" },
   "engines"         : { "node": ">= 0.6.0" }


### PR DESCRIPTION
underscore.string needs to be upgraded because current version depends on jQuery 1.7.2  which has known vulnerabilities http://bugs.jquery.com/ticket/11290 http://research.insecurelabs.org/jquery/test/
