### PR TITLE
Fix two failing tests under io.js

### DIFF
--- a/test/fromfile.js
+++ b/test/fromfile.js
@@ -49,7 +49,7 @@ describe('from file', function () {
       function () {
         args = parser.parseArgs(['@invalid']);
       },
-      /ENOENT, no such file or directory/
+      /ENOENT[:,] no such file or directory/
     );
   });
   it('test reading arguments from an missing file', function () {
@@ -57,7 +57,7 @@ describe('from file', function () {
       function () {
         args = parser.parseArgs(['@missing']);
       },
-      /ENOENT, no such file or directory/
+      /ENOENT[:,] no such file or directory/
     );
   });
   it('test custom convertArgLineToArgs function', function () {


### PR DESCRIPTION
Two tests were failing under io.js because the error message formatting
has changed. Since io.js is the future Node.js, we'd have to fix this
sooner or later. :-)

See nodejs/io.js@bc2c85c and nodejs/io.js#212 for details.