### PR TITLE
Make `new` optional when instantiating ArgumentParser

### DIFF
--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -53,6 +53,9 @@ var Namespace = require('./namespace');
  * [1]:http://docs.python.org/dev/library/argparse.html#argumentparser-objects
  **/
 var ArgumentParser = module.exports = function ArgumentParser(options) {
+  if (!(this instanceof ArgumentParser)) {
+    return new ArgumentParser(options);
+  }
   var self = this;
   options = options || {};
 

--- a/test/base.js
+++ b/test/base.js
@@ -244,4 +244,12 @@ describe('base', function () {
       args = parser.parseArgs([ '-y' ]);
     });
   });
+
+  it('should support instantiation without new', function () {
+    assert.doesNotThrow(function () {
+      /* jshint -W064 */
+      parser = ArgumentParser({debug: true});
+      /* jshint +W064 */
+    });
+  });
 });


### PR DESCRIPTION
These are now equivalent:

- `var parser = ArgumentParser()`
- `var parser = new ArgumentParser()`

I'm a fan of APIs that save you from having to always call `new` on the
constructor function. :-)