### PR TITLE
Add the ability to have multiple description paragraphs by passing an array instead of a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,15 @@ Creates a new ArgumentParser object.
 - ```usage``` - The string describing the program usage (default: generated)
 - ```conflictHandler``` - Usually unnecessary, defines strategy for resolving conflicting optionals.
 
-**Not supportied yet**
+**Not supported yet**
 
 - ```fromfilePrefixChars``` - The set of characters that prefix files from which additional arguments should be read.
 
 
-Details in [original ArgumentParser guide](http://docs.python.org/dev/library/argparse.html#argumentparser-objects)
+Details in [original ArgumentParser guide](http://docs.python.org/dev/library/argparse.html#argumentparser-objects).
+
+Unlike in Python, the `description` key can take both a string and an array
+of strings. When passing an array, a paragraph is added for each string.
 
 
 addArgument() method

--- a/examples/multiple_desc.js
+++ b/examples/multiple_desc.js
@@ -7,8 +7,8 @@ var parser = new ArgumentParser({
   addHelp: true,
   description: [
     'Argparse examples: multiple description paragraphs.',
-    'This is an example of multiple paragraphs in the description. Pass an '
-    + 'array instead of a string to do this.'
+    'This is an example of multiple paragraphs in the description. Pass an ' +
+    'array instead of a string to do this.'
   ],
   epilog: 'help epilog',
   prog: 'help_example_prog'

--- a/examples/multiple_desc.js
+++ b/examples/multiple_desc.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+'use strict';
+
+var ArgumentParser = require('../lib/argparse').ArgumentParser;
+var parser = new ArgumentParser({
+  version: '0.0.1',
+  addHelp: true,
+  description: [
+    'Argparse examples: multiple description paragraphs.',
+    'This is an example of multiple paragraphs in the description. Pass an '
+    + 'array instead of a string to do this.'
+  ],
+  epilog: 'help epilog',
+  prog: 'help_example_prog'
+});
+parser.printHelp();

--- a/lib/help/formatter.js
+++ b/lib/help/formatter.js
@@ -181,7 +181,7 @@ HelpFormatter.prototype.endSection = function () {
 
 /**
  * HelpFormatter#addText(text) -> Void
- * - text (string): plain text
+ * - text (string|array): plain text string or an array of plain text strings
  *
  * Add plain text into current section
  *
@@ -194,8 +194,16 @@ HelpFormatter.prototype.endSection = function () {
  *
  **/
 HelpFormatter.prototype.addText = function (text) {
-  if (!!text && text !== $$.SUPPRESS) {
-    this._addItem(this._formatText, [text]);
+  if (!text) {
+    return;
+  }
+  if (text.constructor !== Array) {
+    this._addText(text);
+  } else {
+    // If this is an array, add multiple sections.
+    for (var n = 0; n < text.length; ++n) {
+      this._addText(text[n]);
+    }
   }
 };
 
@@ -308,6 +316,12 @@ HelpFormatter.prototype._joinParts = function (partStrings) {
   return partStrings.filter(function (part) {
     return (!!part && part !== $$.SUPPRESS);
   }).join('');
+};
+
+HelpFormatter.prototype._addText = function (text) {
+  if (!!text && text !== $$.SUPPRESS) {
+    this._addItem(this._formatText, [text]);
+  }
 };
 
 HelpFormatter.prototype._formatUsage = function (usage, actions, groups, prefix) {


### PR DESCRIPTION
This makes it possible to have multiple paragraphs in the description, in case some more explanation is needed.

For example, in my case, I used argparse for a script that runs a production server, and it was important to me to have an extra paragraph to explain how to ensure that the production environment is proper. Having it all in one description string was inconvenient, and extra linebreaks are not maintained in the string. So this way seemed easiest.

Since argparse previously broke on encountering an array in the `description` key, this is fully backwards compatible for existing implementations.