### PR TITLE
fix: use '=' in args

### DIFF
--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -738,9 +738,8 @@ ArgumentParser.prototype._parseOptional = function (argString) {
 
   // if the option string before the "=" is present, return the action
   if (argString.indexOf('=') >= 0) {
-    var argStringSplit = argString.split('=');
-    optionString = argStringSplit[0];
-    argExplicit = argStringSplit.slice(1).join('=');
+    optionString = argString.split('=', 1)[0];
+    argExplicit = argString.slice(optionString.length + 1);
 
     if (!!this._optionStringActions[optionString]) {
       action = this._optionStringActions[optionString];

--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -740,7 +740,7 @@ ArgumentParser.prototype._parseOptional = function (argString) {
   if (argString.indexOf('=') >= 0) {
     var argStringSplit = argString.split('=');
     optionString = argStringSplit[0];
-    argExplicit = argStringSplit[1];
+    argExplicit = argStringSplit.slice(1).join('=');
 
     if (!!this._optionStringActions[optionString]) {
       action = this._optionStringActions[optionString];

--- a/test/base.js
+++ b/test/base.js
@@ -123,6 +123,16 @@ describe('base', function () {
     args = parser.parseArgs(['-1']);
     assert.equal(args.bar, -1);
   });
+  
+  it("should parse arguments with '='", function () {
+    parser = new ArgumentParser({debug: true});
+    parser.addArgument(['-f', '--foo']);
+    parser.addArgument([ 'bar' ]);
+
+    args = parser.parseArgs('-f="foo=nice=path" "bar=nice=path"'.split(' '));
+    assert.equal(args.foo, '"foo=nice=path"');
+    assert.equal(args.bar, '"bar=nice=path"');
+  });
 
   it("No negative number options; neg number is positional argument", function () {
     parser = new ArgumentParser({debug: true});


### PR DESCRIPTION
Fix error in parse '--examplepath="C:\myfolder\env=x64" '. 