### PR TITLE
Get rid of lodash

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -32,7 +32,7 @@
 
 
 // Constants
-var $$ = require('./const');
+var c = require('./const');
 
 
 /**
@@ -99,9 +99,9 @@ var Action = module.exports = function Action(options) {
 Action.prototype.getName = function () {
   if (this.optionStrings.length > 0) {
     return this.optionStrings.join('/');
-  } else if (this.metavar !== null && this.metavar !== $$.SUPPRESS) {
+} else if (this.metavar !== null && this.metavar !== c.SUPPRESS) {
     return this.metavar;
-  } else if (this.dest !== undefined && this.dest !== $$.SUPPRESS) {
+} else if (this.dest !== undefined && this.dest !== c.SUPPRESS) {
     return this.dest;
   }
   return null;

--- a/lib/action/append.js
+++ b/lib/action/append.js
@@ -47,9 +47,7 @@ util.inherits(ActionAppend, Action);
  * Call the action. Save result in namespace object
  **/
 ActionAppend.prototype.call = function (parser, namespace, values) {
-  var items = [].concat(namespace[this.dest] || []); // or _.clone
+  var items = (namespace[this.dest] || []).slice();
   items.push(values);
   namespace.set(this.dest, items);
 };
-
-

--- a/lib/action/append.js
+++ b/lib/action/append.js
@@ -14,7 +14,7 @@ var util = require('util');
 var Action = require('../action');
 
 // Constants
-var $$ = require('../const');
+var c = require('../const');
 
 /*:nodoc:*
  * new ActionAppend(options)
@@ -30,7 +30,7 @@ var ActionAppend = module.exports = function ActionAppend(options) {
         'strings are not supplying the value to append, ' +
         'the append const action may be more appropriate');
   }
-  if (!!this.constant && this.nargs !== $$.OPTIONAL) {
+  if (!!this.constant && this.nargs !== c.OPTIONAL) {
     throw new Error('nargs must be OPTIONAL to supply const');
   }
   Action.call(this, options);

--- a/lib/action/help.js
+++ b/lib/action/help.js
@@ -11,7 +11,7 @@ var util = require('util');
 var Action = require('../action');
 
 // Constants
-var $$  = require('../const');
+var c  = require('../const');
 
 /*:nodoc:*
  * new ActionHelp(options)
@@ -24,9 +24,9 @@ var ActionHelp = module.exports = function ActionHelp(options) {
     options.defaultValue = options.defaultValue;
   }
   else {
-    options.defaultValue = $$.SUPPRESS;
+    options.defaultValue = c.SUPPRESS;
   }
-  options.dest = (options.dest !== null ? options.dest: $$.SUPPRESS);
+  options.dest = (options.dest !== null ? options.dest: c.SUPPRESS);
   options.nargs = 0;
   Action.call(this, options);
 

--- a/lib/action/store.js
+++ b/lib/action/store.js
@@ -13,7 +13,7 @@ var util = require('util');
 var Action = require('../action');
 
 // Constants
-var $$ = require('../const');
+var c = require('../const');
 
 
 /*:nodoc:*
@@ -29,7 +29,7 @@ var ActionStore = module.exports = function ActionStore(options) {
         'true or store const may be more appropriate');
 
   }
-  if (this.constant !== undefined && this.nargs !== $$.OPTIONAL) {
+  if (this.constant !== undefined && this.nargs !== c.OPTIONAL) {
     throw new Error('nargs must be OPTIONAL to supply const');
   }
   Action.call(this, options);

--- a/lib/action/subparsers.js
+++ b/lib/action/subparsers.js
@@ -14,7 +14,7 @@ var format  = require('util').format;
 var Action = require('../action');
 
 // Constants
-var $$ = require('../const');
+var c = require('../const');
 
 // Errors
 var argumentErrorHelper = require('../argument/error');
@@ -44,8 +44,8 @@ util.inherits(ChoicesPseudoAction, Action);
  **/
 var ActionSubparsers = module.exports = function ActionSubparsers(options) {
   options = options || {};
-  options.dest = options.dest || $$.SUPPRESS;
-  options.nargs = $$.PARSER;
+  options.dest = options.dest || c.SUPPRESS;
+  options.nargs = c.PARSER;
 
   this.debug = (options.debug === true);
 
@@ -125,7 +125,7 @@ ActionSubparsers.prototype.call = function (parser, namespace, values) {
   var argStrings = values.slice(1);
 
   // set the parser name if requested
-  if (this.dest !== $$.SUPPRESS) {
+  if (this.dest !== c.SUPPRESS) {
     namespace[this.dest] = parserName;
   }
 

--- a/lib/action/subparsers.js
+++ b/lib/action/subparsers.js
@@ -9,7 +9,6 @@
 
 var util    = require('util');
 var format  = require('util').format;
-var _       = require('lodash');
 
 
 var Action = require('../action');
@@ -88,7 +87,7 @@ ActionSubparsers.prototype.addParser = function (name, options) {
   var aliases = options.aliases || [];
 
   // create a pseudo-action to hold the choice help
-  if (!!options.help || _.isString(options.help)) {
+  if (!!options.help || typeof options.help === 'string') {
     var help = options.help;
     delete options.help;
 
@@ -137,12 +136,10 @@ ActionSubparsers.prototype.call = function (parser, namespace, values) {
     throw argumentErrorHelper(format(
       'Unknown parser "%s" (choices: [%s]).',
         parserName,
-        _.keys(this._nameParserMap).join(', ')
+        Object.keys(this._nameParserMap).join(', ')
     ));
   }
 
   // parse all the remaining options into the namespace
   parser.parseArgs(argStrings, namespace);
 };
-
-

--- a/lib/action/version.js
+++ b/lib/action/version.js
@@ -13,7 +13,7 @@ var Action = require('../action');
 //
 // Constants
 //
-var $$ = require('../const');
+var c = require('../const');
 
 /*:nodoc:*
  * new ActionVersion(options)
@@ -22,8 +22,8 @@ var $$ = require('../const');
  **/
 var ActionVersion = module.exports = function ActionVersion(options) {
   options = options || {};
-  options.defaultValue = (!!options.defaultValue ? options.defaultValue: $$.SUPPRESS);
-  options.dest = (options.dest || $$.SUPPRESS);
+  options.defaultValue = (!!options.defaultValue ? options.defaultValue: c.SUPPRESS);
+  options.dest = (options.dest || c.SUPPRESS);
   options.nargs = 0;
   this.version = options.version;
   Action.call(this, options);
@@ -45,6 +45,3 @@ ActionVersion.prototype.call = function (parser) {
   formatter.addText(version);
   parser.exit(0, formatter.formatHelp());
 };
-
-
-

--- a/lib/action_container.js
+++ b/lib/action_container.js
@@ -9,9 +9,9 @@
 var format = require('util').format;
 
 // Constants
-var $$ = require('./const');
+var c = require('./const');
 
-var utils = require('./utils');
+var $$ = require('./utils');
 
 //Actions
 var ActionHelp = require('./action/help');
@@ -134,7 +134,7 @@ ActionContainer.prototype.setDefaults = function (options) {
   // if these defaults match any existing arguments, replace the previous
   // default on the object with the new one
   this._actions.forEach(function (action) {
-    if (utils.has(options, action.dest)) {
+    if ($$.has(options, action.dest)) {
       action.defaultValue = options[action.dest];
     }
   });
@@ -147,10 +147,10 @@ ActionContainer.prototype.setDefaults = function (options) {
  * Return action default value
  **/
 ActionContainer.prototype.getDefault = function (dest) {
-  var result = utils.has(this._defaults, dest) ? this._defaults[dest] : null;
+  var result = $$.has(this._defaults, dest) ? this._defaults[dest] : null;
 
   this._actions.forEach(function (action) {
-    if (action.dest === dest && utils.has(action, 'defaultValue')) {
+    if (action.dest === dest && $$.has(action, 'defaultValue')) {
       result = action.defaultValue;
     }
   });
@@ -197,7 +197,7 @@ ActionContainer.prototype.addArgument = function (args, options) {
   // if no default was supplied, use the parser-level default
   if (typeof options.defaultValue === 'undefined') {
     var dest = options.dest;
-    if (utils.has(this._defaults, dest)) {
+    if ($$.has(this._defaults, dest)) {
       options.defaultValue = this._defaults[dest];
   } else if (typeof this.argumentDefault !== 'undefined') {
       options.defaultValue = this.argumentDefault;
@@ -349,10 +349,10 @@ ActionContainer.prototype._getPositional = function (dest, options) {
 
   // mark positional arguments as required if at least one is
   // always required
-  if (options.nargs !== $$.OPTIONAL && options.nargs !== $$.ZERO_OR_MORE) {
+  if (options.nargs !== c.OPTIONAL && options.nargs !== c.ZERO_OR_MORE) {
     options.required = true;
   }
-  if (options.nargs === $$.ZERO_OR_MORE && typeof options.defaultValue === 'undefined') {
+  if (options.nargs === c.ZERO_OR_MORE && typeof options.defaultValue === 'undefined') {
     options.required = true;
   }
 
@@ -390,7 +390,7 @@ ActionContainer.prototype._getOptional = function (args, options) {
 
   if (!dest) {
     var optionStringDest = optionStringsLong.length ? optionStringsLong[0] :optionStrings[0];
-    dest = utils.trimChars(optionStringDest, this.prefixChars);
+    dest = $$.trimChars(optionStringDest, this.prefixChars);
 
     if (dest.length === 0) {
       throw new Error(
@@ -419,7 +419,7 @@ ActionContainer.prototype._popActionClass = function (options, defaultValue) {
 
 ActionContainer.prototype._getHandler = function () {
   var handlerString = this.conflictHandler;
-  var handlerFuncName = "_handleConflict" + utils.capitalize(handlerString);
+  var handlerFuncName = "_handleConflict" + $$.capitalize(handlerString);
   var func = this[handlerFuncName];
   if (typeof func === 'undefined') {
     var msg = "invalid conflict resolution value: " + handlerString;

--- a/lib/action_container.js
+++ b/lib/action_container.js
@@ -7,10 +7,11 @@
 'use strict';
 
 var format = require('util').format;
-var _      = require('lodash');
 
 // Constants
 var $$ = require('./const');
+
+var utils = require('./utils');
 
 //Actions
 var ActionHelp = require('./action/help');
@@ -26,8 +27,6 @@ var ActionSubparsers = require('./action/subparsers');
 
 // Errors
 var argumentErrorHelper = require('./argument/error');
-
-
 
 /**
  * new ActionContainer(options)
@@ -135,7 +134,7 @@ ActionContainer.prototype.setDefaults = function (options) {
   // if these defaults match any existing arguments, replace the previous
   // default on the object with the new one
   this._actions.forEach(function (action) {
-    if (action.dest in options) {
+    if (utils.has(options, action.dest)) {
       action.defaultValue = options[action.dest];
     }
   });
@@ -148,10 +147,10 @@ ActionContainer.prototype.setDefaults = function (options) {
  * Return action default value
  **/
 ActionContainer.prototype.getDefault = function (dest) {
-  var result = (_.has(this._defaults, dest)) ? this._defaults[dest] : null;
+  var result = utils.has(this._defaults, dest) ? this._defaults[dest] : null;
 
   this._actions.forEach(function (action) {
-    if (action.dest === dest && _.has(action, 'defaultValue')) {
+    if (action.dest === dest && utils.has(action, 'defaultValue')) {
       result = action.defaultValue;
     }
   });
@@ -175,10 +174,10 @@ ActionContainer.prototype.addArgument = function (args, options) {
   args = args;
   options = options || {};
 
-  if (!_.isArray(args)) {
+  if (!Array.isArray(args)) {
     throw new TypeError('addArgument first argument should be an array');
   }
-  if (!_.isObject(options) || _.isArray(options)) {
+  if (typeof options !== 'object' || Array.isArray(options)) {
     throw new TypeError('addArgument second argument should be a hash');
   }
 
@@ -196,25 +195,25 @@ ActionContainer.prototype.addArgument = function (args, options) {
   }
 
   // if no default was supplied, use the parser-level default
-  if (_.isUndefined(options.defaultValue)) {
+  if (typeof options.defaultValue === 'undefined') {
     var dest = options.dest;
-    if (_.has(this._defaults, dest)) {
+    if (utils.has(this._defaults, dest)) {
       options.defaultValue = this._defaults[dest];
-    } else if (!_.isUndefined(this.argumentDefault)) {
+  } else if (typeof this.argumentDefault !== 'undefined') {
       options.defaultValue = this.argumentDefault;
     }
   }
 
   // create the action object, and add it to the parser
   var ActionClass = this._popActionClass(options);
-  if (! _.isFunction(ActionClass)) {
+  if (typeof ActionClass !== 'function') {
     throw new Error(format('Unknown action "%s".', ActionClass));
   }
   var action = new ActionClass(options);
 
   // throw an error if the action type is not callable
   var typeFunction = this._registryGet('type', action.type, action.type);
-  if (!_.isFunction(typeFunction)) {
+  if (typeof typeFunction !== 'function') {
     throw new Error(format('"%s" is not callable', typeFunction));
   }
 
@@ -263,7 +262,7 @@ ActionContainer.prototype._addAction = function (action) {
   // set the flag if any option strings look like negative numbers
   action.optionStrings.forEach(function (optionString) {
     if (optionString.match(self._regexpNegativeNumber)) {
-      if (!_.some(self._hasNegativeNumberOptionals)) {
+      if (!self._hasNegativeNumberOptionals.some(Boolean)) {
         self._hasNegativeNumberOptionals.push(true);
       }
     }
@@ -340,8 +339,8 @@ ActionContainer.prototype._addContainerActions = function (container) {
 };
 
 ActionContainer.prototype._getPositional = function (dest, options) {
-  if (_.isArray(dest)) {
-    dest = _.first(dest);
+  if (Array.isArray(dest)) {
+    dest = dest[0];
   }
   // make sure required is not specified
   if (options.required) {
@@ -353,7 +352,7 @@ ActionContainer.prototype._getPositional = function (dest, options) {
   if (options.nargs !== $$.OPTIONAL && options.nargs !== $$.ZERO_OR_MORE) {
     options.required = true;
   }
-  if (options.nargs === $$.ZERO_OR_MORE && options.defaultValue === undefined) {
+  if (options.nargs === $$.ZERO_OR_MORE && typeof options.defaultValue === 'undefined') {
     options.required = true;
   }
 
@@ -391,7 +390,7 @@ ActionContainer.prototype._getOptional = function (args, options) {
 
   if (!dest) {
     var optionStringDest = optionStringsLong.length ? optionStringsLong[0] :optionStrings[0];
-    dest = _.trim(optionStringDest, this.prefixChars);
+    dest = utils.trimChars(optionStringDest, this.prefixChars);
 
     if (dest.length === 0) {
       throw new Error(
@@ -420,7 +419,7 @@ ActionContainer.prototype._popActionClass = function (options, defaultValue) {
 
 ActionContainer.prototype._getHandler = function () {
   var handlerString = this.conflictHandler;
-  var handlerFuncName = "_handleConflict" + _.capitalize(handlerString);
+  var handlerFuncName = "_handleConflict" + utils.capitalize(handlerString);
   var func = this[handlerFuncName];
   if (typeof func === 'undefined') {
     var msg = "invalid conflict resolution value: " + handlerString;
@@ -450,7 +449,7 @@ ActionContainer.prototype._checkConflict = function (action) {
 };
 
 ActionContainer.prototype._handleConflictError = function (action, conflOptionals) {
-  var conflicts = _.map(conflOptionals, function (pair) {return pair[0]; });
+  var conflicts = conflOptionals.map(function (pair) {return pair[0]; });
   conflicts = conflicts.join(', ');
   throw argumentErrorHelper(
     action,

--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -13,9 +13,9 @@ var Path    = require('path');
 var sprintf = require('sprintf-js').sprintf;
 
 // Constants
-var $$ = require('./const');
+var c = require('./const');
 
-var utils = require('./utils');
+var $$ = require('./utils');
 
 var ActionContainer = require('./action_container');
 
@@ -113,7 +113,7 @@ var ArgumentParser = module.exports = function ArgumentParser(options) {
       [defaultPrefix + 'h', defaultPrefix + defaultPrefix + 'help'],
       {
         action: 'help',
-        defaultValue: $$.SUPPRESS,
+        defaultValue: c.SUPPRESS,
         help: 'Show this help message and exit.'
       }
     );
@@ -124,7 +124,7 @@ var ArgumentParser = module.exports = function ArgumentParser(options) {
       {
         action: 'version',
         version: this.version,
-        defaultValue: $$.SUPPRESS,
+        defaultValue: c.SUPPRESS,
         help: "Show program's version number and exit."
       }
     );
@@ -265,9 +265,9 @@ ArgumentParser.prototype.parseKnownArgs = function (args, namespace) {
   namespace = namespace || new Namespace();
 
   self._actions.forEach(function (action) {
-    if (action.dest !== $$.SUPPRESS) {
-      if (!utils.has(namespace, action.dest)) {
-        if (action.defaultValue !== $$.SUPPRESS) {
+    if (action.dest !== c.SUPPRESS) {
+      if (!$$.has(namespace, action.dest)) {
+        if (action.defaultValue !== c.SUPPRESS) {
           var defaultValue = action.defaultValue;
           if (typeof action.defaultValue === 'string') {
             defaultValue = self._getValue(action, defaultValue);
@@ -288,9 +288,9 @@ ArgumentParser.prototype.parseKnownArgs = function (args, namespace) {
 
     namespace = res[0];
     args = res[1];
-    if (utils.has(namespace, $$._UNRECOGNIZED_ARGS_ATTR)) {
-      args = utils.arrayUnion(args, namespace[$$._UNRECOGNIZED_ARGS_ATTR]);
-      delete namespace[$$._UNRECOGNIZED_ARGS_ATTR];
+    if ($$.has(namespace, c._UNRECOGNIZED_ARGS_ATTR)) {
+      args = $$.arrayUnion(args, namespace[c._UNRECOGNIZED_ARGS_ATTR]);
+      delete namespace[c._UNRECOGNIZED_ARGS_ATTR];
     }
     return [namespace, args];
   } catch (e) {
@@ -326,7 +326,7 @@ ArgumentParser.prototype._parseKnownArgs = function (argStrings, namespace) {
   this._mutuallyExclusiveGroups.forEach(function (mutexGroup) {
     mutexGroup._groupActions.forEach(function (mutexAction, i, groupActions) {
       key = actionHash(mutexAction);
-      if (!utils.has(actionConflicts, key)) {
+      if (!$$.has(actionConflicts, key)) {
         actionConflicts[key] = [];
       }
       conflicts = actionConflicts[key];
@@ -392,7 +392,7 @@ ArgumentParser.prototype._parseKnownArgs = function (argStrings, namespace) {
       }
     }
 
-    if (argumentValues !== $$.SUPPRESS) {
+    if (argumentValues !== c.SUPPRESS) {
       action.call(self, namespace, argumentValues, optionString);
     }
   }
@@ -597,7 +597,7 @@ ArgumentParser.prototype._parseKnownArgs = function (argStrings, namespace) {
       if (!actionUsed) {
         var names = [];
         group._groupActions.forEach(function (action) {
-          if (action.help !== $$.SUPPRESS) {
+          if (action.help !== c.SUPPRESS) {
             names.push(action.getName());
           }
         });
@@ -661,10 +661,10 @@ ArgumentParser.prototype._matchArgument = function (action, regexpArgStrings) {
     case null:
       message = 'Expected one argument.';
       break;
-    case $$.OPTIONAL:
+    case c.OPTIONAL:
       message = 'Expected at most one argument.';
       break;
-    case $$.ONE_OR_MORE:
+    case c.ONE_OR_MORE:
       message = 'Expected at least one argument.';
       break;
     default:
@@ -851,28 +851,28 @@ ArgumentParser.prototype._getNargsPattern = function (action) {
     regexpNargs = '(-*A-*)';
     break;
   // allow zero or more arguments
-  case $$.OPTIONAL:
+  case c.OPTIONAL:
     regexpNargs = '(-*A?-*)';
     break;
   // allow zero or more arguments
-  case $$.ZERO_OR_MORE:
+  case c.ZERO_OR_MORE:
     regexpNargs = '(-*[A-]*)';
     break;
   // allow one or more arguments
-  case $$.ONE_OR_MORE:
+  case c.ONE_OR_MORE:
     regexpNargs = '(-*A[A-]*)';
     break;
   // allow any number of options or arguments
-  case $$.REMAINDER:
+  case c.REMAINDER:
     regexpNargs = '([-AO]*)';
     break;
   // allow one argument followed by any number of options or arguments
-  case $$.PARSER:
+  case c.PARSER:
     regexpNargs = '(-*A[-AO]*)';
     break;
   // all others should be integers
   default:
-    regexpNargs = '(-*' + utils.repeat('-*A', action.nargs) + '-*)';
+    regexpNargs = '(-*' + $$.repeat('-*A', action.nargs) + '-*)';
   }
 
   // if this is an optional action, -- is not allowed
@@ -893,7 +893,7 @@ ArgumentParser.prototype._getValues = function (action, argStrings) {
   var self = this;
 
   // for everything but PARSER args, strip out '--'
-  if (action.nargs !== $$.PARSER && action.nargs !== $$.REMAINDER) {
+  if (action.nargs !== c.PARSER && action.nargs !== c.REMAINDER) {
     argStrings = argStrings.filter(function (arrayElement) {
       return arrayElement !== '--';
     });
@@ -902,7 +902,7 @@ ArgumentParser.prototype._getValues = function (action, argStrings) {
   var value, argString;
 
   // optional argument produces a default when not present
-  if (argStrings.length === 0 && action.nargs === $$.OPTIONAL) {
+  if (argStrings.length === 0 && action.nargs === c.OPTIONAL) {
 
     value = (action.isOptional()) ? action.constant: action.defaultValue;
 
@@ -913,7 +913,7 @@ ArgumentParser.prototype._getValues = function (action, argStrings) {
 
   // when nargs='*' on a positional, if there were no command-line
   // args, use the default if it is anything other than None
-  } else if (argStrings.length === 0 && action.nargs === $$.ZERO_OR_MORE &&
+  } else if (argStrings.length === 0 && action.nargs === c.ZERO_OR_MORE &&
     action.optionStrings.length === 0) {
 
     value = (action.defaultValue || argStrings);
@@ -921,20 +921,20 @@ ArgumentParser.prototype._getValues = function (action, argStrings) {
 
   // single argument or optional argument produces a single value
   } else if (argStrings.length === 1 &&
-        (!action.nargs || action.nargs === $$.OPTIONAL)) {
+        (!action.nargs || action.nargs === c.OPTIONAL)) {
 
     argString = argStrings[0];
     value = this._getValue(action, argString);
     this._checkValue(action, value);
 
   // REMAINDER arguments convert all values, checking none
-  } else if (action.nargs === $$.REMAINDER) {
+  } else if (action.nargs === c.REMAINDER) {
     value = argStrings.map(function (v) {
       return self._getValue(action, v);
     });
 
   // PARSER arguments convert all values, but check only the first
-  } else if (action.nargs === $$.PARSER) {
+  } else if (action.nargs === c.PARSER) {
     value = argStrings.map(function (v) {
       return self._getValue(action, v);
     });
@@ -1156,7 +1156,7 @@ ArgumentParser.prototype.error = function (err) {
   else {
     message = err;
   }
-  var msg = format('%s: error: %s', this.prog, message) + $$.EOL;
+  var msg = format('%s: error: %s', this.prog, message) + c.EOL;
 
   if (this.debug === true) {
     throw new Error(msg);

--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -10,12 +10,12 @@
 var util    = require('util');
 var format  = require('util').format;
 var Path    = require('path');
-
-var _       = require('lodash');
 var sprintf = require('sprintf-js').sprintf;
 
 // Constants
 var $$ = require('./const');
+
+var utils = require('./utils');
 
 var ActionContainer = require('./action_container');
 
@@ -184,7 +184,7 @@ ArgumentParser.prototype.addSubparsers = function (options) {
     var positionals = this._getPositionalActions();
     var groups = this._mutuallyExclusiveGroups;
     formatter.addUsage(this.usage, positionals, groups, '');
-    options.prog = _.trim(formatter.formatHelp());
+    options.prog = formatter.formatHelp().trim();
   }
 
   // create the parsers action and add it to the positionals list
@@ -266,10 +266,10 @@ ArgumentParser.prototype.parseKnownArgs = function (args, namespace) {
 
   self._actions.forEach(function (action) {
     if (action.dest !== $$.SUPPRESS) {
-      if (!_.has(namespace, action.dest)) {
+      if (!utils.has(namespace, action.dest)) {
         if (action.defaultValue !== $$.SUPPRESS) {
           var defaultValue = action.defaultValue;
-          if (_.isString(action.defaultValue)) {
+          if (typeof action.defaultValue === 'string') {
             defaultValue = self._getValue(action, defaultValue);
           }
           namespace[action.dest] = defaultValue;
@@ -278,7 +278,7 @@ ArgumentParser.prototype.parseKnownArgs = function (args, namespace) {
     }
   });
 
-  _.keys(self._defaults).forEach(function (dest) {
+  Object.keys(self._defaults).forEach(function (dest) {
     namespace[dest] = self._defaults[dest];
   });
 
@@ -288,8 +288,8 @@ ArgumentParser.prototype.parseKnownArgs = function (args, namespace) {
 
     namespace = res[0];
     args = res[1];
-    if (_.has(namespace, $$._UNRECOGNIZED_ARGS_ATTR)) {
-      args = _.union(args, namespace[$$._UNRECOGNIZED_ARGS_ATTR]);
+    if (utils.has(namespace, $$._UNRECOGNIZED_ARGS_ATTR)) {
+      args = utils.arrayUnion(args, namespace[$$._UNRECOGNIZED_ARGS_ATTR]);
       delete namespace[$$._UNRECOGNIZED_ARGS_ATTR];
     }
     return [namespace, args];
@@ -326,7 +326,7 @@ ArgumentParser.prototype._parseKnownArgs = function (argStrings, namespace) {
   this._mutuallyExclusiveGroups.forEach(function (mutexGroup) {
     mutexGroup._groupActions.forEach(function (mutexAction, i, groupActions) {
       key = actionHash(mutexAction);
-      if (!_.has(actionConflicts, key)) {
+      if (!utils.has(actionConflicts, key)) {
         actionConflicts[key] = [];
       }
       conflicts = actionConflicts[key];
@@ -428,13 +428,12 @@ ArgumentParser.prototype._parseKnownArgs = function (argStrings, namespace) {
           var newExplicitArg = explicitArg.slice(1) || null;
           var optionalsMap = self._optionStringActions;
 
-          if (_.keys(optionalsMap).indexOf(optionString) >= 0) {
+          if (Object.keys(optionalsMap).indexOf(optionString) >= 0) {
             action = optionalsMap[optionString];
             explicitArg = newExplicitArg;
           }
           else {
-            var msg = 'ignored explicit argument %r';
-            throw argumentErrorHelper(action, msg);
+            throw argumentErrorHelper(action, sprintf('ignored explicit argument %r', explicitArg));
           }
         }
         // if the action expect exactly one argument, we've
@@ -448,8 +447,7 @@ ArgumentParser.prototype._parseKnownArgs = function (argStrings, namespace) {
         // error if a double-dash option did not use the
         // explicit argument
         else {
-          var message = 'ignored explicit argument %r';
-          throw argumentErrorHelper(action, sprintf(message, explicitArg));
+          throw argumentErrorHelper(action, sprintf('ignored explicit argument %r', explicitArg));
         }
       }
       // if there is no explicit argument, try to match the
@@ -494,17 +492,17 @@ ArgumentParser.prototype._parseKnownArgs = function (argStrings, namespace) {
 
     // slice off the appropriate arg strings for each Positional
     // and add the Positional and its args to the list
-    _.zip(positionals, argCounts).forEach(function (item) {
-        var action = item[0];
-        var argCount = item[1];
-        if (argCount === undefined) {
-          return;
-        }
-        var args = argStrings.slice(startIndex, startIndex + argCount);
+    for (var i = 0; i < positionals.length; i++) {
+      var action = positionals[i];
+      var argCount = argCounts[i];
+      if (argCount === undefined) {
+        continue;
+      }
+      var args = argStrings.slice(startIndex, startIndex + argCount);
 
-        startIndex += argCount;
-        takeAction(action, args);
-      });
+      startIndex += argCount;
+      takeAction(action, args);
+    }
 
     // slice off the Positionals that we just parsed and return the
     // index at which the Positionals' string args stopped
@@ -581,7 +579,7 @@ ArgumentParser.prototype._parseKnownArgs = function (argStrings, namespace) {
   // make sure all required actions were present
   self._actions.forEach(function (action) {
     if (action.required) {
-      if (_.indexOf(seenActions, action) < 0) {
+      if (seenActions.indexOf(action) < 0) {
         self.error(format('Argument "%s" is required', action.getName()));
       }
     }
@@ -591,8 +589,8 @@ ArgumentParser.prototype._parseKnownArgs = function (argStrings, namespace) {
   var actionUsed = false;
   self._mutuallyExclusiveGroups.forEach(function (group) {
     if (group.required) {
-      actionUsed = _.some(group._groupActions, function (action) {
-        return _.includes(seenNonDefaultActions, action);
+      actionUsed = group._groupActions.some(function (action) {
+        return seenNonDefaultActions.indexOf(action) !== -1;
       });
 
       // if no actions were used, report the error
@@ -773,7 +771,7 @@ ArgumentParser.prototype._parseOptional = function (argString) {
   // number, it was meant to be positional
   // unless there are negative-number-like options
   if (argString.match(this._regexpNegativeNumber)) {
-    if (!_.some(this._hasNegativeNumberOptionals)) {
+    if (!this._hasNegativeNumberOptionals.some(Boolean)) {
       return null;
     }
   }
@@ -874,7 +872,7 @@ ArgumentParser.prototype._getNargsPattern = function (action) {
     break;
   // all others should be integers
   default:
-    regexpNargs = '(-*' + _.repeat('-*A', action.nargs) + '-*)';
+    regexpNargs = '(-*' + utils.repeat('-*A', action.nargs) + '-*)';
   }
 
   // if this is an optional action, -- is not allowed
@@ -960,7 +958,7 @@ ArgumentParser.prototype._getValue = function (action, argString) {
   var result;
 
   var typeFunction = this._registryGet('type', action.type, action.type);
-  if (!_.isFunction(typeFunction)) {
+  if (typeof typeFunction !== 'function') {
     var message = format('%s is not callable', typeFunction);
     throw argumentErrorHelper(action, message);
   }
@@ -975,7 +973,7 @@ ArgumentParser.prototype._getValue = function (action, argString) {
     // Failing that, include the error message it raised.
   } catch (e) {
     var name = null;
-    if (_.isString(action.type)) {
+    if (typeof action.type === 'string') {
       name = action.type;
     } else {
       name = action.type.name || action.type.displayName || '<function>';
@@ -993,23 +991,23 @@ ArgumentParser.prototype._checkValue = function (action, value) {
   var choices = action.choices;
   if (!!choices) {
     // choise for argument can by array or string
-    if ((_.isString(choices) || _.isArray(choices)) &&
+    if ((typeof choices === 'string' || Array.isArray(choices)) &&
         choices.indexOf(value) !== -1) {
       return;
     }
     // choise for subparsers can by only hash
-    if (_.isObject(choices) && !_.isArray(choices) && choices[value]) {
+    if (typeof choices === 'object' && !Array.isArray(choices) && choices[value]) {
       return;
     }
 
-    if (_.isString(choices)) {
+    if (typeof choices === 'string') {
       choices = choices.split('').join(', ');
     }
-    else if (_.isArray(choices)) {
+    else if (Array.isArray(choices)) {
       choices =  choices.join(', ');
     }
     else {
-      choices =  _.keys(choices).join(', ');
+      choices =  Object.keys(choices).join(', ');
     }
     var message = format('Invalid choice: %s (choose from [%s])', value, choices);
     throw argumentErrorHelper(action, message);

--- a/lib/help/added_formatters.js
+++ b/lib/help/added_formatters.js
@@ -1,12 +1,11 @@
 'use strict';
 
 var util    = require('util');
-var _       = require('lodash');
-
 
 // Constants
 var $$ = require('../const');
 
+var utils = require('../utils');
 var HelpFormatter = require('./formatter.js');
 
 /**
@@ -59,7 +58,7 @@ util.inherits(RawDescriptionHelpFormatter, HelpFormatter);
 RawDescriptionHelpFormatter.prototype._fillText = function (text, width, indent) {
   var lines = text.split('\n');
   lines = lines.map(function (line) {
-      return _.trimEnd(indent + line);
+      return utils.trimEnd(indent + line);
     });
   return lines.join('\n');
 };

--- a/lib/help/added_formatters.js
+++ b/lib/help/added_formatters.js
@@ -3,9 +3,9 @@
 var util    = require('util');
 
 // Constants
-var $$ = require('../const');
+var c = require('../const');
 
-var utils = require('../utils');
+var $$ = require('../utils');
 var HelpFormatter = require('./formatter.js');
 
 /**
@@ -27,8 +27,8 @@ util.inherits(ArgumentDefaultsHelpFormatter, HelpFormatter);
 ArgumentDefaultsHelpFormatter.prototype._getHelpString = function (action) {
   var help = action.help;
   if (action.help.indexOf('%(defaultValue)s') === -1) {
-    if (action.defaultValue !== $$.SUPPRESS) {
-      var defaulting_nargs = [$$.OPTIONAL, $$.ZERO_OR_MORE];
+    if (action.defaultValue !== c.SUPPRESS) {
+      var defaulting_nargs = [c.OPTIONAL, c.ZERO_OR_MORE];
       if (action.isOptional() || (defaulting_nargs.indexOf(action.nargs) >= 0)) {
         help += ' (default: %(defaultValue)s)';
       }
@@ -58,7 +58,7 @@ util.inherits(RawDescriptionHelpFormatter, HelpFormatter);
 RawDescriptionHelpFormatter.prototype._fillText = function (text, width, indent) {
   var lines = text.split('\n');
   lines = lines.map(function (line) {
-      return utils.trimEnd(indent + line);
+      return $$.trimEnd(indent + line);
     });
   return lines.join('\n');
 };

--- a/lib/help/formatter.js
+++ b/lib/help/formatter.js
@@ -13,11 +13,12 @@
  **/
 'use strict';
 
-var _ = require('lodash');
 var sprintf = require('sprintf-js').sprintf;
 
 // Constants
 var $$ = require('../const');
+
+var utils = require('../utils');
 
 
 /*:nodoc:* internal
@@ -80,7 +81,7 @@ Section.prototype.formatHelp = function (formatter) {
   heading = '';
   if (!!this._heading && this._heading !== $$.SUPPRESS) {
     var currentIndent = formatter.currentIndent;
-    heading = _.repeat(' ', currentIndent) + this._heading + ':' + $$.EOL;
+    heading = utils.repeat(' ', currentIndent) + this._heading + ':' + $$.EOL;
   }
 
   // join the section-initialize newline, the heading and the help
@@ -299,7 +300,7 @@ HelpFormatter.prototype.formatHelp = function () {
   var help = this._rootSection.formatHelp(this);
   if (help) {
     help = help.replace(this._longBreakMatcher, $$.EOL + $$.EOL);
-    help = _.trim(help, $$.EOL) + $$.EOL;
+    help = utils.trimChars(help, $$.EOL) + $$.EOL;
   }
   return help;
 };
@@ -311,7 +312,7 @@ HelpFormatter.prototype._joinParts = function (partStrings) {
 };
 
 HelpFormatter.prototype._formatUsage = function (usage, actions, groups, prefix) {
-  if (!prefix && !_.isString(prefix)) {
+  if (!prefix && typeof prefix !== 'string') {
     prefix = 'usage: ';
   }
 
@@ -397,7 +398,7 @@ HelpFormatter.prototype._formatUsage = function (usage, actions, groups, prefix)
       var lines, indent, parts;
       // if prog is short, follow it with optionals or positionals
       if (prefix.length + prog.length <= 0.75 * textWidth) {
-        indent = _.repeat(' ', (prefix.length + prog.length + 1));
+        indent = utils.repeat(' ', (prefix.length + prog.length + 1));
         if (optionalParts) {
           lines = [].concat(
             _getLines([prog].concat(optionalParts), indent, prefix),
@@ -411,7 +412,7 @@ HelpFormatter.prototype._formatUsage = function (usage, actions, groups, prefix)
 
         // if prog is long, put it on its own line
       } else {
-        indent = _.repeat(' ', prefix.length);
+        indent = utils.repeat(' ', prefix.length);
         parts = optionalParts + positionalParts;
         lines = _getLines(parts, indent);
         if (lines.length > 1) {
@@ -446,7 +447,7 @@ HelpFormatter.prototype._formatActionsUsage = function (actions, groups) {
       end = start + group._groupActions.length;
 
       //if (actions.slice(start, end) === group._groupActions) {
-      if (_.isEqual(actions.slice(start, end), group._groupActions)) {
+      if (utils.arrayEqual(actions.slice(start, end), group._groupActions)) {
         group._groupActions.forEach(function (action) {
           groupActions.push(action);
         });
@@ -549,7 +550,7 @@ HelpFormatter.prototype._formatActionsUsage = function (actions, groups) {
   text = text.replace(/\( *\)/g, '');
   text = text.replace(/\(([^|]*)\)/g, '$1'); // remove () from single action groups
 
-  text = _.trim(text);
+  text = text.trim();
 
   // return the text
   return text;
@@ -558,7 +559,7 @@ HelpFormatter.prototype._formatActionsUsage = function (actions, groups) {
 HelpFormatter.prototype._formatText = function (text) {
   text = sprintf(text, {prog: this._prog});
   var textWidth = this._width - this._currentIndent;
-  var indentIncriment = _.repeat(' ', this._currentIndent);
+  var indentIncriment = utils.repeat(' ', this._currentIndent);
   return this._fillText(text, textWidth, indentIncriment) + $$.EOL + $$.EOL;
 };
 
@@ -578,19 +579,19 @@ HelpFormatter.prototype._formatAction = function (action) {
 
   // no help; start on same line and add a final newline
   if (!action.help) {
-    actionHeader = _.repeat(' ', this._currentIndent) + actionHeader + $$.EOL;
+    actionHeader = utils.repeat(' ', this._currentIndent) + actionHeader + $$.EOL;
 
   // short action name; start on the same line and pad two spaces
   } else if (actionHeader.length <= actionWidth) {
-    actionHeader = _.repeat(' ', this._currentIndent) +
+    actionHeader = utils.repeat(' ', this._currentIndent) +
         actionHeader +
         '  ' +
-        _.repeat(' ', actionWidth - actionHeader.length);
+        utils.repeat(' ', actionWidth - actionHeader.length);
     indentFirst = 0;
 
   // long action name; start on the next line
   } else {
-    actionHeader = _.repeat(' ', this._currentIndent) + actionHeader + $$.EOL;
+    actionHeader = utils.repeat(' ', this._currentIndent) + actionHeader + $$.EOL;
     indentFirst = helpPosition;
   }
 
@@ -601,9 +602,9 @@ HelpFormatter.prototype._formatAction = function (action) {
   if (!!action.help) {
     helpText = this._expandHelp(action);
     helpLines = this._splitLines(helpText, helpWidth);
-    parts.push(_.repeat(' ', indentFirst) + helpLines[0] + $$.EOL);
+    parts.push(utils.repeat(' ', indentFirst) + helpLines[0] + $$.EOL);
     helpLines.slice(1).forEach(function (line) {
-      parts.push(_.repeat(' ', helpPosition) + line + $$.EOL);
+      parts.push(utils.repeat(' ', helpPosition) + line + $$.EOL);
     });
 
   // or add a newline if the description doesn't end with one
@@ -656,14 +657,14 @@ HelpFormatter.prototype._metavarFormatter = function (action, metavarDefault) {
   } else if (!!action.choices) {
     var choices = action.choices;
 
-    if (_.isString(choices)) {
+    if (typeof choices === 'string') {
       choices = choices.split('').join(', ');
-    } else if (_.isArray(choices)) {
+    } else if (Array.isArray(choices)) {
       choices = choices.join(',');
     }
     else
     {
-      choices = _.keys(choices).join(',');
+      choices = Object.keys(choices).join(',');
     }
     result = '{' + choices + '}';
   } else {
@@ -733,14 +734,14 @@ HelpFormatter.prototype._expandHelp = function (action) {
   });
 
   if (!!params.choices) {
-    if (_.isString(params.choices)) {
+    if (typeof params.choices === 'string') {
       params.choices = params.choices.split('').join(', ');
     }
-    else if (_.isArray(params.choices)) {
+    else if (Array.isArray(params.choices)) {
       params.choices = params.choices.join(', ');
     }
     else {
-      params.choices = _.keys(params.choices).join(', ');
+      params.choices = Object.keys(params.choices).join(', ');
     }
   }
 
@@ -754,7 +755,7 @@ HelpFormatter.prototype._splitLines = function (text, width) {
 
   text = text.replace(/[\n\|\t]/g, ' ');
 
-  text = _.trim(text);
+  text = text.trim();
   text = text.replace(this._whitespaceMatcher, ' ');
 
   // Wraps the single paragraph in text (a string) so every line

--- a/lib/help/formatter.js
+++ b/lib/help/formatter.js
@@ -16,9 +16,9 @@
 var sprintf = require('sprintf-js').sprintf;
 
 // Constants
-var $$ = require('../const');
+var c = require('../const');
 
-var utils = require('../utils');
+var $$ = require('../utils');
 
 
 /*:nodoc:* internal
@@ -79,13 +79,13 @@ Section.prototype.formatHelp = function (formatter) {
 
   // add the heading if the section was non-empty
   heading = '';
-  if (!!this._heading && this._heading !== $$.SUPPRESS) {
+  if (!!this._heading && this._heading !== c.SUPPRESS) {
     var currentIndent = formatter.currentIndent;
-    heading = utils.repeat(' ', currentIndent) + this._heading + ':' + $$.EOL;
+    heading = $$.repeat(' ', currentIndent) + this._heading + ':' + c.EOL;
   }
 
   // join the section-initialize newline, the heading and the help
-  return formatter._joinParts([$$.EOL, heading, itemHelp, $$.EOL]);
+  return formatter._joinParts([c.EOL, heading, itemHelp, c.EOL]);
 };
 
 /**
@@ -115,7 +115,7 @@ var HelpFormatter = module.exports = function HelpFormatter(options) {
   this._currentSection = this._rootSection;
 
   this._whitespaceMatcher = new RegExp('\\s+', 'g');
-  this._longBreakMatcher = new RegExp($$.EOL + $$.EOL + $$.EOL + '+', 'g');
+  this._longBreakMatcher = new RegExp(c.EOL + c.EOL + c.EOL + '+', 'g');
 };
 
 HelpFormatter.prototype._indent = function () {
@@ -195,7 +195,7 @@ HelpFormatter.prototype.endSection = function () {
  *
  **/
 HelpFormatter.prototype.addText = function (text) {
-  if (!!text && text !== $$.SUPPRESS) {
+  if (!!text && text !== c.SUPPRESS) {
     this._addItem(this._formatText, [text]);
   }
 };
@@ -216,7 +216,7 @@ HelpFormatter.prototype.addText = function (text) {
  *
  **/
 HelpFormatter.prototype.addUsage = function (usage, actions, groups, prefix) {
-  if (usage !== $$.SUPPRESS) {
+  if (usage !== c.SUPPRESS) {
     this._addItem(this._formatUsage, [usage, actions, groups, prefix]);
   }
 };
@@ -230,7 +230,7 @@ HelpFormatter.prototype.addUsage = function (usage, actions, groups, prefix) {
  * Single variant of [[HelpFormatter#addArguments]]
  **/
 HelpFormatter.prototype.addArgument = function (action) {
-  if (action.help !== $$.SUPPRESS) {
+  if (action.help !== c.SUPPRESS) {
     var self = this;
 
     // find all invocations
@@ -299,15 +299,15 @@ HelpFormatter.prototype.addArguments = function (actions) {
 HelpFormatter.prototype.formatHelp = function () {
   var help = this._rootSection.formatHelp(this);
   if (help) {
-    help = help.replace(this._longBreakMatcher, $$.EOL + $$.EOL);
-    help = utils.trimChars(help, $$.EOL) + $$.EOL;
+    help = help.replace(this._longBreakMatcher, c.EOL + c.EOL);
+    help = $$.trimChars(help, c.EOL) + c.EOL;
   }
   return help;
 };
 
 HelpFormatter.prototype._joinParts = function (partStrings) {
   return partStrings.filter(function (part) {
-    return (!!part && part !== $$.SUPPRESS);
+    return (!!part && part !== c.SUPPRESS);
   }).join('');
 };
 
@@ -398,7 +398,7 @@ HelpFormatter.prototype._formatUsage = function (usage, actions, groups, prefix)
       var lines, indent, parts;
       // if prog is short, follow it with optionals or positionals
       if (prefix.length + prog.length <= 0.75 * textWidth) {
-        indent = utils.repeat(' ', (prefix.length + prog.length + 1));
+        indent = $$.repeat(' ', (prefix.length + prog.length + 1));
         if (optionalParts) {
           lines = [].concat(
             _getLines([prog].concat(optionalParts), indent, prefix),
@@ -412,7 +412,7 @@ HelpFormatter.prototype._formatUsage = function (usage, actions, groups, prefix)
 
         // if prog is long, put it on its own line
       } else {
-        indent = utils.repeat(' ', prefix.length);
+        indent = $$.repeat(' ', prefix.length);
         parts = optionalParts + positionalParts;
         lines = _getLines(parts, indent);
         if (lines.length > 1) {
@@ -424,12 +424,12 @@ HelpFormatter.prototype._formatUsage = function (usage, actions, groups, prefix)
         lines = [prog] + lines;
       }
       // join lines into usage
-      usage = lines.join($$.EOL);
+      usage = lines.join(c.EOL);
     }
   }
 
   // prefix with 'usage:'
-  return prefix + usage + $$.EOL + $$.EOL;
+  return prefix + usage + c.EOL + c.EOL;
 };
 
 HelpFormatter.prototype._formatActionsUsage = function (actions, groups) {
@@ -447,7 +447,7 @@ HelpFormatter.prototype._formatActionsUsage = function (actions, groups) {
       end = start + group._groupActions.length;
 
       //if (actions.slice(start, end) === group._groupActions) {
-      if (utils.arrayEqual(actions.slice(start, end), group._groupActions)) {
+      if ($$.arrayEqual(actions.slice(start, end), group._groupActions)) {
         group._groupActions.forEach(function (action) {
           groupActions.push(action);
         });
@@ -487,7 +487,7 @@ HelpFormatter.prototype._formatActionsUsage = function (actions, groups) {
 
     // suppressed arguments are marked with None
     // remove | separators for suppressed arguments
-    if (action.help === $$.SUPPRESS) {
+    if (action.help === c.SUPPRESS) {
       parts.push(null);
       if (inserts[actionIndex] === '|') {
         inserts.splice(actionIndex, actionIndex);
@@ -559,8 +559,8 @@ HelpFormatter.prototype._formatActionsUsage = function (actions, groups) {
 HelpFormatter.prototype._formatText = function (text) {
   text = sprintf(text, {prog: this._prog});
   var textWidth = this._width - this._currentIndent;
-  var indentIncriment = utils.repeat(' ', this._currentIndent);
-  return this._fillText(text, textWidth, indentIncriment) + $$.EOL + $$.EOL;
+  var indentIncriment = $$.repeat(' ', this._currentIndent);
+  return this._fillText(text, textWidth, indentIncriment) + c.EOL + c.EOL;
 };
 
 HelpFormatter.prototype._formatAction = function (action) {
@@ -579,19 +579,19 @@ HelpFormatter.prototype._formatAction = function (action) {
 
   // no help; start on same line and add a final newline
   if (!action.help) {
-    actionHeader = utils.repeat(' ', this._currentIndent) + actionHeader + $$.EOL;
+    actionHeader = $$.repeat(' ', this._currentIndent) + actionHeader + c.EOL;
 
   // short action name; start on the same line and pad two spaces
   } else if (actionHeader.length <= actionWidth) {
-    actionHeader = utils.repeat(' ', this._currentIndent) +
+    actionHeader = $$.repeat(' ', this._currentIndent) +
         actionHeader +
         '  ' +
-        utils.repeat(' ', actionWidth - actionHeader.length);
+        $$.repeat(' ', actionWidth - actionHeader.length);
     indentFirst = 0;
 
   // long action name; start on the next line
   } else {
-    actionHeader = utils.repeat(' ', this._currentIndent) + actionHeader + $$.EOL;
+    actionHeader = $$.repeat(' ', this._currentIndent) + actionHeader + c.EOL;
     indentFirst = helpPosition;
   }
 
@@ -602,14 +602,14 @@ HelpFormatter.prototype._formatAction = function (action) {
   if (!!action.help) {
     helpText = this._expandHelp(action);
     helpLines = this._splitLines(helpText, helpWidth);
-    parts.push(utils.repeat(' ', indentFirst) + helpLines[0] + $$.EOL);
+    parts.push($$.repeat(' ', indentFirst) + helpLines[0] + c.EOL);
     helpLines.slice(1).forEach(function (line) {
-      parts.push(utils.repeat(' ', helpPosition) + line + $$.EOL);
+      parts.push($$.repeat(' ', helpPosition) + line + c.EOL);
     });
 
   // or add a newline if the description doesn't end with one
-  } else if (actionHeader.charAt(actionHeader.length - 1) !== $$.EOL) {
-    parts.push($$.EOL);
+  } else if (actionHeader.charAt(actionHeader.length - 1) !== c.EOL) {
+    parts.push(c.EOL);
   }
   // if there are any sub-actions, add their help as well
   if (!!action._getSubactions) {
@@ -696,22 +696,22 @@ HelpFormatter.prototype._formatArgs = function (action, metavarDefault) {
     metavars = buildMetavar(1);
     result = '' + metavars[0];
     break;
-  case $$.OPTIONAL:
+  case c.OPTIONAL:
     metavars = buildMetavar(1);
     result = '[' + metavars[0] + ']';
     break;
-  case $$.ZERO_OR_MORE:
+  case c.ZERO_OR_MORE:
     metavars = buildMetavar(2);
     result = '[' + metavars[0] + ' [' + metavars[1] + ' ...]]';
     break;
-  case $$.ONE_OR_MORE:
+  case c.ONE_OR_MORE:
     metavars = buildMetavar(2);
     result = '' + metavars[0] + ' [' + metavars[1] + ' ...]';
     break;
-  case $$.REMAINDER:
+  case c.REMAINDER:
     result = '...';
     break;
-  case $$.PARSER:
+  case c.PARSER:
     metavars = buildMetavar(1);
     result = metavars[0] + ' ...';
     break;
@@ -728,7 +728,7 @@ HelpFormatter.prototype._expandHelp = function (action) {
   Object.keys(action).forEach(function (actionProperty) {
     var actionValue = action[actionProperty];
 
-    if (actionValue !== $$.SUPPRESS) {
+    if (actionValue !== c.SUPPRESS) {
       params[actionProperty] = actionValue;
     }
   });
@@ -760,7 +760,7 @@ HelpFormatter.prototype._splitLines = function (text, width) {
 
   // Wraps the single paragraph in text (a string) so every line
   // is at most width characters long.
-  text.split($$.EOL).forEach(function (line) {
+  text.split(c.EOL).forEach(function (line) {
     if (width >= line.length) {
       lines.push(line);
       return;
@@ -791,7 +791,7 @@ HelpFormatter.prototype._fillText = function (text, width, indent) {
   lines = lines.map(function (line) {
     return indent + line;
   });
-  return lines.join($$.EOL);
+  return lines.join(c.EOL);
 };
 
 HelpFormatter.prototype._getHelpString = function (action) {

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -10,7 +10,7 @@
  **/
 'use strict';
 
-var _ = require('lodash');
+var utils = require('./utils');
 
 /**
  * new Namespace(options)
@@ -18,7 +18,7 @@ var _ = require('lodash');
  *
  **/
 var Namespace = module.exports = function Namespace(options) {
-  _.extend(this, options);
+  utils.extend(this, options);
 };
 
 /**
@@ -28,7 +28,7 @@ var Namespace = module.exports = function Namespace(options) {
  * Tells whenever `namespace` contains given `key` or not.
  **/
 Namespace.prototype.isset = function (key) {
-  return _.has(this, key);
+  return utils.has(this, key);
 };
 
 /**
@@ -41,7 +41,7 @@ Namespace.prototype.isset = function (key) {
  **/
 Namespace.prototype.set = function (key, value) {
   if (typeof (key) === 'object') {
-    _.extend(this, key);
+    utils.extend(this, key);
   } else {
     this[key] = value;
   }

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -10,7 +10,7 @@
  **/
 'use strict';
 
-var utils = require('./utils');
+var $$ = require('./utils');
 
 /**
  * new Namespace(options)
@@ -18,7 +18,7 @@ var utils = require('./utils');
  *
  **/
 var Namespace = module.exports = function Namespace(options) {
-  utils.extend(this, options);
+  $$.extend(this, options);
 };
 
 /**
@@ -28,7 +28,7 @@ var Namespace = module.exports = function Namespace(options) {
  * Tells whenever `namespace` contains given `key` or not.
  **/
 Namespace.prototype.isset = function (key) {
-  return utils.has(this, key);
+  return $$.has(this, key);
 };
 
 /**
@@ -41,7 +41,7 @@ Namespace.prototype.isset = function (key) {
  **/
 Namespace.prototype.set = function (key, value) {
   if (typeof (key) === 'object') {
-    utils.extend(this, key);
+    $$.extend(this, key);
   } else {
     this[key] = value;
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,55 @@
+'use strict';
+
+exports.repeat = function (str, num) {
+  var result = '';
+  for (var i = 0; i < num; i++) { result += str; }
+  return result;
+};
+
+exports.arrayEqual = function (a, b) {
+  if (a.length !== b.length) { return false; }
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) { return false; }
+  }
+  return true;
+};
+
+exports.trimChars = function (str, chars) {
+  var start = 0;
+  var end = str.length - 1;
+  while (chars.indexOf(str.charAt(start)) >= 0) { start++; }
+  while (chars.indexOf(str.charAt(end)) >= 0) { end--; }
+  return str.slice(start, end + 1);
+};
+
+exports.capitalize = function (str) {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+};
+
+exports.arrayUnion = function () {
+  var result = [];
+  for (var i = 0, values = {}; i < arguments.length; i++) {
+    var arr = arguments[i];
+    for (var j = 0; j < arr.length; j++) {
+      if (!values[arr[j]]) {
+        values[arr[j]] = true;
+        result.push(arr[j]);
+      }
+    }
+  }
+  return result;
+};
+
+exports.extend = function (dest, src) {
+    for (var i in src) {
+        dest[i] = src[i];
+    }
+};
+
+exports.has = function (obj, key) {
+    return obj.hasOwnProperty(key);
+};
+
+exports.trimEnd = function (str) {
+    return str.replace(/\s+$/g, '');
+};

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "test": "make test"
   },
   "dependencies": {
-    "lodash": ">= 4.0.0 < 5.0.0",
     "sprintf-js": "~1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Gets rid of the huge Lodash dependency (weighing 4Mb) by replacing its usage with ordinary native JavaScript. ~~Also gets rid of "sprintf-js" (just because it was easy too).~~

This makes installs of any module that indirectly depends on `argparser` much faster (in particular, `js-yaml` and `eslint`).

See also: https://github.com/nodeca/js-yaml/issues/246 https://github.com/nodeca/js-yaml/pull/247

cc @puzrin @Floby