### PR TITLE
Fix typos in ActionContainer#addArgument docstring

### DIFF
--- a/lib/action_container.js
+++ b/lib/action_container.js
@@ -169,8 +169,8 @@ ActionContainer.prototype.getDefault = function (dest) {
  * - options (Object): action objects see [[Action.new]]
  *
  * #### Examples
- * - addArgument([-f, --foo], {action:'store', defaultValue=1, ...})
- * - addArgument(['bar'], action: 'store', nargs:1, ...})
+ * - addArgument([ '-f', '--foo' ], { action: 'store', defaultValue: 1, ... })
+ * - addArgument([ 'bar' ], { action: 'store', nargs: 1, ... })
  **/
 ActionContainer.prototype.addArgument = function (args, options) {
   args = args;


### PR DESCRIPTION
- Flags `[ '-f', '--foo' ]` were missing quotes
- Options for `bar` were missing opening brace
- bar's `defaultValue` was using an equal (`=`), not a colon (`:`)

Those lines have also been tweaked to better match the eslint rules for
the project.