### PR TITLE
Teach addArgument to accept string arg names

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ parser.addArgument(
     help: 'bar foo'
   }
 );
+parser.addArgument(
+  '--baz',
+  {
+    help: 'baz bar'
+  }
+);
 var args = parser.parseArgs();
 console.dir(args);
 ```
@@ -50,7 +56,7 @@ Display help:
 
 ```
 $ ./test.js -h
-usage: example.js [-h] [-v] [-f FOO] [-b BAR]
+usage: example.js [-h] [-v] [-f FOO] [-b BAR] [--baz BAZ]
 
 Argparse example
 
@@ -59,13 +65,14 @@ Optional arguments:
   -v, --version      Show program's version number and exit.
   -f FOO, --foo FOO  foo bar
   -b BAR, --bar BAR  bar foo
+  --baz BAZ          baz bar
 ```
 
 Parse arguments:
 
 ```
-$ ./test.js -f=3 --bar=4
-{ foo: '3', bar: '4' }
+$ ./test.js -f=3 --bar=4 --baz 5
+{ foo: '3', bar: '4', baz: '5' }
 ```
 
 More [examples](https://github.com/nodeca/argparse/tree/master/examples).
@@ -105,12 +112,15 @@ addArgument() method
 ====================
 
 ```
-ArgumentParser.addArgument([names or flags], {options})
+ArgumentParser.addArgument(name or flag or [name] or [flags...], {options})
 ```
 
 Defines how a single command-line argument should be parsed.
 
-- ```name or flags``` - Either a name or a list of option strings, e.g. foo or -f, --foo.
+- ```name or flag or [name] or [flags...]``` - Either a positional name
+  (e.g., `'foo'`), a single option (e.g., `'-f'` or `'--foo'`), an array
+  of a single positional name (e.g., `['foo']`), or an array of options
+  (e.g., `['-f', '--foo']`).
 
 Options:
 

--- a/examples/arguments.js
+++ b/examples/arguments.js
@@ -19,6 +19,12 @@ parser.addArgument(
     help: 'bar foo'
   }
 );
+parser.addArgument(
+  '--baz',
+  {
+    help: 'baz bar'
+  }
+);
 
 
 parser.printHelp();
@@ -32,5 +38,8 @@ args = parser.parseArgs('-f=3 --bar=4'.split(' '));
 console.dir(args);
 console.log('-----------');
 args = parser.parseArgs('--foo 5 --bar 6'.split(' '));
+console.dir(args);
+console.log('-----------');
+args = parser.parseArgs('--baz 7 -f 8'.split(' '));
 console.dir(args);
 console.log('-----------');

--- a/lib/action_container.js
+++ b/lib/action_container.js
@@ -165,19 +165,23 @@ ActionContainer.prototype.getDefault = function (dest) {
 
 /**
  * ActionContainer#addArgument(args, options) -> Object
- * - args (Array): array of argument keys
+ * - args (String|Array): argument key, or array of argument keys
  * - options (Object): action objects see [[Action.new]]
  *
  * #### Examples
  * - addArgument([ '-f', '--foo' ], { action: 'store', defaultValue: 1, ... })
  * - addArgument([ 'bar' ], { action: 'store', nargs: 1, ... })
+ * - addArgument('--baz', { action: 'store', nargs: 1, ... })
  **/
 ActionContainer.prototype.addArgument = function (args, options) {
   args = args;
   options = options || {};
 
+  if (typeof args === 'string') {
+    args = [ args ];
+  }
   if (!Array.isArray(args)) {
-    throw new TypeError('addArgument first argument should be an array');
+    throw new TypeError('addArgument first argument should be a string or an array');
   }
   if (typeof options !== 'object' || Array.isArray(options)) {
     throw new TypeError('addArgument second argument should be a hash');

--- a/test/base.js
+++ b/test/base.js
@@ -261,4 +261,25 @@ describe('base', function () {
       parser = ArgumentParser({ debug: true });
     });
   });
+
+  it('should accept a string as a positional argument name', function () {
+    parser = new ArgumentParser({ debug: true });
+    parser.addArgument('foo');
+    args = parser.parseArgs([ 'badger' ]);
+    assert.equal(args.foo, 'badger');
+  });
+
+  it('should accept a string as a short option name', function () {
+    parser = new ArgumentParser({ debug: true });
+    parser.addArgument('-f');
+    args = parser.parseArgs('-f badger'.split(' '));
+    assert.equal(args.f, 'badger');
+  });
+
+  it('should accept a string as a long option name', function () {
+    parser = new ArgumentParser({ debug: true });
+    parser.addArgument('--foo');
+    args = parser.parseArgs('--foo badger'.split(' '));
+    assert.equal(args.foo, 'badger');
+  });
 });


### PR DESCRIPTION
ActionContainer#addArgument can now accept a string as its first
argument, which will be interpreted as a single option name or
positional name.

This better matches Python's add_argument signature in the common case
of a single argument name.