### PR TITLE
Use .concat instead of + for arrays

### DIFF
--- a/lib/help/formatter.js
+++ b/lib/help/formatter.js
@@ -414,7 +414,7 @@ HelpFormatter.prototype._formatUsage = function (usage, actions, groups, prefix)
         // if prog is long, put it on its own line
       } else {
         indent = $$.repeat(' ', prefix.length);
-        parts = optionalParts + positionalParts;
+        parts = optionalParts.concat(positionalParts);
         lines = _getLines(parts, indent);
         if (lines.length > 1) {
           lines = [].concat(
@@ -422,7 +422,7 @@ HelpFormatter.prototype._formatUsage = function (usage, actions, groups, prefix)
             _getLines(positionalParts, indent)
           );
         }
-        lines = [ prog ] + lines;
+        lines = [ prog ].concat(lines);
       }
       // join lines into usage
       usage = lines.join(c.EOL);

--- a/test/formatters.js
+++ b/test/formatters.js
@@ -255,4 +255,18 @@ optional arguments:
   -z [Z1]           z
 */
   });
+
+  it('HelpFormatter addUsage -- regression test for long prefixes', function () {
+    parser = new argparse.HelpFormatter({ prog: 'prog' });
+    var mockAction = {
+      isOptional: function () { return true; },
+      optionStrings: [ 'a' ],
+      dest: 'dest'
+    };
+    var longPrefix = 'really really really really really really really really really long prefix';
+    parser.addUsage(null, [ mockAction ], [], longPrefix);
+    var helperText = parser.formatHelp();
+    assert(helperText.match(longPrefix));
+    assert(helperText.match('DEST'));
+  });
 });


### PR DESCRIPTION
* When adding arrays together using + operator, it outputs a string
* This causes the call to `_getLines` to break, because `_getLines` expects an array in it's first parameter and causes an exception when it calls `parts.forEach`
* Changed the two instances to use `.concat` instead
* Tested this locally with Appium
  *  `appium --help` before this change had the `parts.forEach` error
  * `appium --help` after this change showed the docs as expected