### PR TITLE
bug fixed: In ActionAppend, I fixed a bug that defaultValue is append…

### DIFF
--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -272,7 +272,9 @@ ArgumentParser.prototype.parseKnownArgs = function (args, namespace) {
           if (typeof action.defaultValue === 'string') {
             defaultValue = self._getValue(action, defaultValue);
           }
-          namespace[action.dest] = defaultValue;
+          if (action.constructor.name != 'ActionAppend') {
+            namespace[action.dest] = defaultValue;
+          }
         }
       }
     }
@@ -292,6 +294,15 @@ ArgumentParser.prototype.parseKnownArgs = function (args, namespace) {
       args = $$.arrayUnion(args, namespace[c._UNRECOGNIZED_ARGS_ATTR]);
       delete namespace[c._UNRECOGNIZED_ARGS_ATTR];
     }
+
+    self._actions.forEach(function (action) {
+      if (action.constructor.name == 'ActionAppend') {
+        if (typeof namespace[action.dest] === 'undefined') {
+          namespace[action.dest] = action.defaultValue;
+        }
+      }
+    });
+
     return [ namespace, args ];
   } catch (e) {
     this.error(e);


### PR DESCRIPTION
Hello.
The following is a very simple code that have wrong behavior.

```
const argparse =require('argparse');
parser = new argparse.ArgumentParser();

parser.addArgument(
    ['--foo'],
    {
        action: 'append',
        defaultValue: ["1", "2"],
    }
);

var args = parser.parseArgs();
console.log(args);

```

```
$ node test.js --foo 5 --foo 6
Namespace { foo: [ '1', '2', '5', '6' ] }
```

The answer I expected is "5". However the result is [1, 2, 5].
My opinion is that the default value should not be shown in the result when a user input of the argument '--foo' is given.