### PR TITLE
Remove "null" after message "Expected one argument."

### DIFF
--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -666,7 +666,7 @@ ArgumentParser.prototype._matchArgument = function (action, regexpArgStrings) {
 
     throw argumentErrorHelper(
       action,
-      format(message, action.nargs)
+      format(message, action.nargs || '')
     );
   }
   // return the number of arguments matched


### PR DESCRIPTION
In my project I have following command:

```
$ h1 dns record-set list --zone-name
usage: h1 dns record-set list [-h] [--output {table,tsv,list,json}] [--query QUERY] [--transform TRANSFORM] --zone-name ZONE-NAME [--tenant-select TENANT-SELECT] [--verbose] [--no-wait] [--dry-run]
h1 dns record-set list: error: argument "--zone-name": Expected one argument. null
```
There is only one required parameter. 

At the end of message I have "null". It should not be present and it is clear that this code will be added in this code if case ```action.nargs === null```.