### PR TITLE
Change 'usage:' to 'Usage:'

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Display help:
 
 ```
 $ ./test.js -h
-usage: example.js [-h] [-v] [-f FOO] [-b BAR] [--baz BAZ]
+Usage: example.js [-h] [-v] [-f FOO] [-b BAR] [--baz BAZ]
 
 Argparse example
 

--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -178,7 +178,7 @@ ArgumentParser.prototype.addSubparsers = function (options) {
   }
 
   // prog defaults to the usage message of this parser, skipping
-  // optional arguments and with no "usage:" prefix
+  // optional arguments and with no "Usage:" prefix
   if (!options.prog) {
     var formatter = this._getFormatter();
     var positionals = this._getPositionalActions();

--- a/lib/help/formatter.js
+++ b/lib/help/formatter.js
@@ -313,7 +313,7 @@ HelpFormatter.prototype._joinParts = function (partStrings) {
 
 HelpFormatter.prototype._formatUsage = function (usage, actions, groups, prefix) {
   if (!prefix && typeof prefix !== 'string') {
-    prefix = 'usage: ';
+    prefix = 'Usage: ';
   }
 
   actions = actions || [];
@@ -429,7 +429,7 @@ HelpFormatter.prototype._formatUsage = function (usage, actions, groups, prefix)
     }
   }
 
-  // prefix with 'usage:'
+  // prefix with 'Usage:'
   return prefix + usage + c.EOL + c.EOL;
 };
 

--- a/test/conflict.js
+++ b/test/conflict.js
@@ -38,20 +38,20 @@ describe('Argument conflict handling', function () {
     parser.addArgument([ '-x' ], { help: 'NEW X' });
     help = parser.formatHelp();
     /* expect
-    usage: PROG [-h] [-x X]
+    Usage: PROG [-h] [-x X]
 
     optional arguments:
       -h, --help  show this help message and exit
       -x X        NEW X
     */
-    assert(help.match(/usage: PROG \[-h\] \[-x X\]/im));
+    assert(help.match(/Usage: PROG \[-h\] \[-x X\]/im));
     assert(help.match(/Show this help message and exit/im));
     assert(help.match(/-x X\s*NEW X/im));
     parser.addArgument([ '--spam' ], { metavar: 'OLD_SPAM' });
     parser.addArgument([ '--spam' ], { metavar: 'NEW_SPAM' });
     help = parser.formatHelp();
     /* expect
-    usage: PROG [-h] [-x X] [--spam NEW_SPAM]
+    Usage: PROG [-h] [-x X] [--spam NEW_SPAM]
 
     optional arguments:
       -h, --help       show this help message and exit
@@ -75,7 +75,7 @@ describe('Argument conflict handling', function () {
     parser.addArgument([ '--bar' ]);
     help = parser.formatHelp();
     /*
-    usage: _mocha [-h] [-f FOO] [--bar BAR]
+    Usage: _mocha [-h] [-f FOO] [--bar BAR]
     Optional arguments:
       -h, --help         Show this help message and exit.
       -f FOO, --foo FOO
@@ -87,7 +87,7 @@ describe('Argument conflict handling', function () {
     assert(help.match(/-f FOO$/im));
     assert(help.match(/--foo FOO, --bar FOO, --foobar FOO/im));
     /*
-    usage: _mocha [-h] [-f FOO] [--foo FOO]
+    Usage: _mocha [-h] [-f FOO] [--foo FOO]
     Optional arguments:
       -h, --help            Show this help message and exit.
       -f FOO

--- a/test/group.js
+++ b/test/group.js
@@ -118,10 +118,10 @@ describe('group', function () {
       /Not allowed with argument/i
     );
     usage = parser.formatUsage();
-    assert.equal(usage, 'usage: PROG [-h] (--bar BAR | --baz [BAZ])\n');
+    assert.equal(usage, 'Usage: PROG [-h] (--bar BAR | --baz [BAZ])\n');
     group.required = false;
     usage = parser.formatUsage();
-    assert.equal(usage, 'usage: PROG [-h] [--bar BAR | --baz [BAZ]]\n');
+    assert.equal(usage, 'Usage: PROG [-h] [--bar BAR | --baz [BAZ]]\n');
     // could also test all or part of parser.formatHelp()
   });
 
@@ -147,10 +147,10 @@ describe('group', function () {
       /Not allowed with argument/i
     );
     usage = parser.formatUsage();
-    assert.equal(usage, 'usage: PROG [-h] (--foo | --spam SPAM | badger [badger ...])\n');
+    assert.equal(usage, 'Usage: PROG [-h] (--foo | --spam SPAM | badger [badger ...])\n');
     group.required = false;
     usage = parser.formatUsage();
-    assert.equal(usage, 'usage: PROG [-h] [--foo | --spam SPAM | badger [badger ...]]\n');
+    assert.equal(usage, 'Usage: PROG [-h] [--foo | --spam SPAM | badger [badger ...]]\n');
   });
 
   it('two mutually exclusive groups', function () {
@@ -164,7 +164,7 @@ describe('group', function () {
     group2.addArgument([ '--soup' ], { action: 'storeTrue' });
     group2.addArgument([ '--nuts' ], { action: 'storeFalse' });
     usage = parser.formatUsage();
-    assert.equal(usage, 'usage: PROG [-h] (--foo | --bar) [--soup | --nuts]\n');
+    assert.equal(usage, 'Usage: PROG [-h] (--foo | --bar) [--soup | --nuts]\n');
   });
 
   it('suppressed and single action groups', function () {
@@ -178,6 +178,6 @@ describe('group', function () {
     group2.addArgument([ '--xxx' ], {});
     // single entry in a required group, remove group ()
     usage = parser.formatUsage();
-    assert.equal(usage, 'usage: PROG [-h]  --xxx XXX\n');
+    assert.equal(usage, 'Usage: PROG [-h]  --xxx XXX\n');
   });
 });


### PR DESCRIPTION
In the default help text, both "Optional arguments:" and "Examples:" start with an upper-case letter. 

For consistency reasons, the literal "usage:" should therefore be changed to "Usage:".

I looked through some of the `--help` pages of popular linux commands like `ls`, `cp`, `mkdir`, `mv`, `rm`, etc. and they all use "Usage:" instead of "usage:".