### PR TITLE
Fix underscore.string ReDos in 0.1.x branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name"            : "argparse",
   "description"     : "Very powerful CLI arguments parser. Native port of argparse - python's options parsing library",
-  "version"         : "0.1.16",
+  "version"         : "0.1.17",
   "keywords"        : ["cli", "parser", "argparse", "option", "args"],
   "homepage"        : "https://github.com/nodeca/argparse",
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 
    "dependencies"   : {
                         "underscore"        : "~1.7.0",
-                        "underscore.string" : "~2.4.0"
+                        "underscore.string" : "~3.3.5"
                       },
   "devDependencies" : { "mocha": "*" }
 }


### PR DESCRIPTION
Hiya.

I work on Modernizr: https://github.com/Modernizr/Modernizr/issues/2396
...which depends on Remarkable: https://github.com/jonschlinkert/remarkable/pull/312
...which depends on argparse. :)

Packages upstream from you are [being flagged with a vulnerability](https://snyk.io/vuln/npm:underscore.string:20170908), which is creating all sorts of noise. (Obviously, you're not at fault, but you know.. it happens...)

Modern argparse moved to lodash and doesn't have this issue anymore. However, some maintainers would [prefer a patch version](https://github.com/jonschlinkert/remarkable/pull/312#issuecomment-447502661) instead of upgrading to a major release and worrying about other compatibility changes.

I made the necessary changes from your last 0.1.x patch release and tests look good.
**Would you be open to shipping a 0.1.17 npm package with this change?**
(I suppose it would make sense merge into a v0.1.x branch in your repo, but that's up to you. :)

Thank you!

cc @jonschlinkert @mschipperheyn @rejas @foolip