### PR TITLE
fix: correctly show long strings in help output

### DIFF
--- a/lib/help/formatter.js
+++ b/lib/help/formatter.js
@@ -768,7 +768,11 @@ HelpFormatter.prototype._splitLines = function (text, width) {
     while (wrapEnd <= line.length) {
       if (wrapEnd !== line.length && delimiters.indexOf(line[wrapEnd] < -1)) {
         delimiterIndex = (re.exec(line.substring(wrapStart, wrapEnd)) || {}).index;
-        wrapEnd = wrapStart + delimiterIndex + 1;
+        if (!delimiterIndex) {
+          wrapEnd = line.length;
+        } else {
+          wrapEnd = wrapStart + delimiterIndex + 1;
+        }
       }
       lines.push(line.substring(wrapStart, wrapEnd));
       wrapStart = wrapEnd;

--- a/test/formatters.js
+++ b/test/formatters.js
@@ -256,6 +256,29 @@ optional arguments:
 */
   });
 
+  it('should correctly wrap very long lines', function () {
+    parser = new argparse.ArgumentParser({
+      prog: 'PROG'
+    });
+
+    var longPath = '/a/really/really/really/really/really/really/really/really/long/path';
+    parser.addArgument([ '-w' ], {
+      help: 'this an argument that by default is set to ' + longPath
+    });
+
+    helptext = parser.formatHelp();
+    assert(helptext.match(longPath));
+
+/*
+usage: PROG [-h] [-w W]
+
+optional arguments:
+  -h, --help        show this help message and exit
+  -w                this an argument that by default is set to
+                    /a/really/really/really/really/really/really/really/really/long/path
+*/
+  });
+
   it('HelpFormatter addUsage -- regression test for long prefixes', function () {
     parser = new argparse.HelpFormatter({ prog: 'prog' });
     var mockAction = {


### PR DESCRIPTION
This is a fix for #141, which I ran into today as well. 

Current behavior causes very long help strings not to be displayed in help output; instead, a duplicate of the previous line is shown (see #141).

This fix addresses that - a test has been included for verification also.

Thank you for this great library!