### PR TITLE
Add documentation for the version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Creates a new ArgumentParser object.
 - ```prog``` - The name of the program (default: `path.basename(process.argv[1])`)
 - ```usage``` - The string describing the program usage (default: generated)
 - ```conflictHandler``` - Usually unnecessary, defines strategy for resolving conflicting optionals.
+- ```version``` - The version of the program.
 
 **Not supported yet**
 

--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -47,6 +47,7 @@ var Namespace = require('./namespace');
  * - `debug`  Enable debug mode. Argument errors throw exception in
  *   debug mode and process.exit in normal. Used for development and
  *   testing (default: false)
+ * - `version` The version of the program
  *
  * See also [original guide][1]
  *


### PR DESCRIPTION
Add documentation for the `version` option of the `ArgumentParser` constructor.