### PR TITLE
Removed illegal placeholder "%r", which seems to be unsupported

### DIFF
--- a/lib/argument_parser.js
+++ b/lib/argument_parser.js
@@ -431,7 +431,7 @@ ArgumentParser.prototype._parseKnownArgs = function (argStrings, namespace) {
             action = optionalsMap[optionString];
             explicitArg = newExplicitArg;
           } else {
-            throw argumentErrorHelper(action, sprintf('ignored explicit argument %r', explicitArg));
+            throw argumentErrorHelper(action, sprintf('ignored explicit argument %s', explicitArg));
           }
         } else if (argCount === 1) {
           // if the action expect exactly one argument, we've
@@ -443,7 +443,7 @@ ArgumentParser.prototype._parseKnownArgs = function (argStrings, namespace) {
         } else {
           // error if a double-dash option did not use the
           // explicit argument
-          throw argumentErrorHelper(action, sprintf('ignored explicit argument %r', explicitArg));
+          throw argumentErrorHelper(action, sprintf('ignored explicit argument %s', explicitArg));
         }
       } else {
         // if there is no explicit argument, try to match the


### PR DESCRIPTION
This leads to crashes for me in certain situations (such as `<program> -f0`  where -f is a valid flag that does not accept a value).