### PR TITLE
Support nodejs versions below 10.3.0

### DIFF
--- a/argparse.js
+++ b/argparse.js
@@ -219,7 +219,7 @@ function _alias(object, from, to) {
                 name, from, name, to)),
             enumerable: false
         })
-    } catch {}
+    } catch (e) {}
 }
 
 // decorator that allows snake_case class methods to be called with camelCase and vice versa


### PR DESCRIPTION
Per https://node.green/#ES2019-misc-optional-catch-binding ,
support for "catch {}" is only available in Node 10.3 and later.