### PR TITLE
Change license in package.json from Python-2.0 to PSF-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "argparse.js",
     "lib/"
   ],
-  "license": "Python-2.0",
+  "license": "PSF-2.0",
   "repository": "nodeca/argparse",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
I believe that the correct identifier for this license is PSF-2.0.

https://spdx.org/licenses/PSF-2.0.html

Making this change allows automated tooling to work more effectively.