### PR TITLE
update license to GPL compatible Python-2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "argparse.js",
     "lib/"
   ],
-  "license": "Python-2.0",
+  "license": "Python-2.0.1",
   "repository": "nodeca/argparse",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
According to maintainer comment [1] it is acceptable to update the license to something that is GPL compatible and not confusing for license checkers. While authors in general want to make it GPL compatible, just want to use an identifier that wouldn't confuse license checkers. That's why I file this pull request to hopefully achieve that.

I think that being GPL compatible is much more important than keeping broken license checkers happy. But maybe this PR would be a straightforward option either way.

To summarise, according to FSF [2] Python 2.0 license "is a free software license but is incompatible with the GNU GPL". While Python 2.0.1 and 2.1.1 licenses are GPL compatible.

The license under identifier `PSF-2.0` is *probably* equivalent to `Python-2.0.1` but is not referred to neither by OSI, nor FSF so is safer to be left aside for the time being.

My suggestion is to change the license identifier of argparse to `Python-2.0.1` that is provably accepted by FSF as GPL compatible as well recognized by SPDX.

I also opened a pull request with SPDX [3] to mark it as FSF aproved in the main table, based on the official FSF link posted below [2], to make that more easily discoverable.

Regards.

PS supersedes #170
PPS also in previous issues, some stated that argparse was derived from a later python version than 2.0 so it would be correct or at least more logical to be licensed as "Python-2.0.1" corresponding to the license version used by the later python versions

[1] https://github.com/nodeca/argparse/issues/162#issuecomment-854895204
[2] https://www.gnu.org/licenses/license-list.en.html#Python
[3] https://github.com/spdx/license-list-XML/pull/1929