### PR TITLE
Update argparse.js

### DIFF
--- a/argparse.js
+++ b/argparse.js
@@ -219,7 +219,7 @@ function _alias(object, from, to) {
                 name, from, name, to)),
             enumerable: false
         })
-    } catch {}
+    } catch (e) {}
 }
 
 // decorator that allows snake_case class methods to be called with camelCase and vice versa


### PR DESCRIPTION
Fix: Update catch statement syntax for compatibility with WeChat Mini Program

Problem: The empty parameter catch {} statement at line 222 causes syntax errors in WeChat Mini Program and other JavaScript environments that require catch parameters.

Solution: Changed catch {} to catch (e) {} to maintain compatibility while preserving the original error handling behavior.

Impact:

✅ Backward compatible
✅ No functional changes
✅ Fixes syntax errors in restricted JavaScript environments ✅ Maintains existing error handling logic