### PR TITLE
Update license field to Python-2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "files": [
     "lib/"
   ],
-  "license": "Python-2.0",
+  "license": "Python-2.0.1",
   "repository": "nodeca/argparse",
   "funding": [
     {


### PR DESCRIPTION
Hi,
while preparing a new package for Fedora that use argparse as dependency I found that the Python-2.0 is not allowed in Fedora.

Fortunately the real license is the SPDX Python-2.0.1 so update the license field to reflect that.

In the past only the Python-2.0 was available in SPDX but later the Python-2.0.1 was added, so use it.